### PR TITLE
Fixed wrong packetId on restore

### DIFF
--- a/src/brainCloudBase.js
+++ b/src/brainCloudBase.js
@@ -110,6 +110,9 @@ function BrainCloudManager ()
         if(sessionId !== null || sessionId !== "")
         {
             bcm._isAuthenticated = true;
+        }
+        else
+        {
             bcm._packetId = -1; 
         }
         bcm._sessionId = sessionId;


### PR DESCRIPTION
When `setSessionId` is called with null or empty sessionId, we have to set the last packetId to -1. The original code was doing the inverse.