### PR TITLE
Fixed inconsistencies using bccm doc tool

### DIFF
--- a/src/brainCloudClient-friend.js
+++ b/src/brainCloudClient-friend.js
@@ -137,6 +137,20 @@ function BCFriend() {
 	};
 
 	/**
+     * @deprecated Use readFriendUserState() instead - Removal after March 1 2022
+	 */
+	bc.friend.readFriendPlayerState = function(friendId, callback) {
+		bc.brainCloudManager.sendRequest({
+			service: bc.SERVICE_FRIEND,
+			operation: bc.friend.OPERATION_READ_FRIEND_PLAYER_STATE,
+			data: {
+				friendId: friendId
+			},
+			callback: callback
+		});
+	};
+
+	/**
 	 * Read a friend's state.
 	 *
 	 * Service Name - PlayerState
@@ -145,7 +159,7 @@ function BCFriend() {
 	 * @param friendId Target friend
 	 * @param callback Method to be invoked when the server response is received.
 	 */
-	bc.friend.readFriendPlayerState = function(friendId, callback) {
+	bc.friend.readFriendUserState = function(friendId, callback) {
 		bc.brainCloudManager.sendRequest({
 			service: bc.SERVICE_FRIEND,
 			operation: bc.friend.OPERATION_READ_FRIEND_PLAYER_STATE,

--- a/src/brainCloudClient-globalentity.js
+++ b/src/brainCloudClient-globalentity.js
@@ -283,6 +283,26 @@ function BCGlobalEntity() {
 	};
 
 	/**
+     * @deprecated Use updateEntityTimeToLive() instead - Removal after March 1 2022
+	 */
+	bc.globalEntity.updateEntityUpdateTimeToLive = function(entityId,
+																		  timeToLive, version, callback) {
+		var message = {
+			entityId : entityId,
+			version : version,
+			timeToLive : timeToLive
+		};
+
+		bc.brainCloudManager
+			.sendRequest({
+				service : bc.SERVICE_GLOBAL_ENTITY,
+				operation : bc.globalEntity.OPERATION_UPDATE_TIME_TO_LIVE,
+				data : message,
+				callback : callback
+			});
+	};
+
+	/**
 	 * Method updates an existing entity's time to live on the server.
 	 *
 	 * Service Name - globalEntity
@@ -293,8 +313,7 @@ function BCGlobalEntity() {
 	 * @param version The version of the entity to update
 	 * @param callback The callback object
 	 */
-	bc.globalEntity.updateEntityUpdateTimeToLive = function(entityId,
-																		  timeToLive, version, callback) {
+	bc.globalEntity.updateEntityTimeToLive = function(entityId, timeToLive, version, callback) {
 		var message = {
 			entityId : entityId,
 			version : version,

--- a/src/brainCloudClient-identity.js
+++ b/src/brainCloudClient-identity.js
@@ -407,7 +407,7 @@ function BCIdentity() {
      * @param callback The method to be invoked when the server response is received
      *
      */
-    bc.identity.mergeGoogleIdentity = function(googleOpenId, authenticationToken, callback) {
+    bc.identity.mergeGoogleOpenIdIdentity = function(googleOpenId, authenticationToken, callback) {
         bc.identity.mergeIdentity(googleOpenId, authenticationToken, bc.authentication.AUTHENTICATION_TYPE_GOOGLE_OPEN_ID, callback);
     };
 
@@ -425,7 +425,7 @@ function BCIdentity() {
      * disconnecting this identity would result in the profile being anonymous (which means that
      * the profile wouldn't be retrievable if the user loses their device)
      */
-    bc.identity.detachGoogleIdentity = function(googleOpenId, continueAnon, callback) {
+    bc.identity.detachGoogleOpenIdIdentity = function(googleOpenId, continueAnon, callback) {
         bc.identity.detachIdentity(googleOpenId, bc.authentication.AUTHENTICATION_TYPE_GOOGLE_OPEN_ID, continueAnon, callback);
     };
 

--- a/src/brainCloudClient-rttservice.js
+++ b/src/brainCloudClient-rttservice.js
@@ -37,9 +37,16 @@ function BCRTT() {
     }
 
     /**
-     * Returns true if RTT is enabled
+     * @deprecated Use isRTTEnabled instead. Will be removed on March 1 2022
      */
     bc.rttService.getRTTEnabled = function() {
+        return bc.brainCloudRttComms.isRTTEnabled();
+    }
+
+    /**
+     * Returns true if RTT is enabled
+     */
+    bc.rttService.isRTTEnabled = function() {
         return bc.brainCloudRttComms.isRTTEnabled();
     }
 

--- a/src/brainCloudClient-social-leaderboards.js
+++ b/src/brainCloudClient-social-leaderboards.js
@@ -203,6 +203,29 @@ function BCSocialLeaderboard() {
     };
 
     /**
+     * Gets the number of entries in a global leaderboard
+     *
+     * Service Name - leaderboard
+     * Service Operation - GET_GLOBAL_LEADERBOARD_ENTRY_COUNT
+     *
+     * @param leaderboardId The leaderboard ID
+     * @param versionId Version of the leaderboard
+     * @param callback The method to be invoked when the server response is received
+     */
+    bc.socialLeaderboard.getGlobalLeaderboardEntryCountByVersion = function(leaderboardId, versionId, callback) {
+        bc.brainCloudManager
+            .sendRequest({
+                service : bc.SERVICE_LEADERBOARD,
+                operation : bc.socialLeaderboard.OPERATION_GET_GLOBAL_LEADERBOARD_ENTRY_COUNT,
+                data : {
+                    leaderboardId : leaderboardId,
+                    versionId: versionId
+                },
+                callback : callback
+            });
+    };
+
+    /**
      * Method returns the social leaderboard. A player's social leaderboard is
      * comprised of players who are recognized as being your friend.
      * For now, this applies solely to Facebook connected players who are
@@ -358,23 +381,7 @@ function BCSocialLeaderboard() {
     };
 
     /**
-     * Post the players score to the given social leaderboard.
-     * Pass leaderboard config data to dynamically create if necessary.
-     * You can optionally send a user-defined json string of data
-     * with the posted score. This string could include information
-     * relevant to the posted score.
-     *
-     * Service Name - SocialLeaderboard
-     * Service Operation - PostScoreDynamic
-     *
-     * @param leaderboardName The leaderboard to post to
-     * @param score The score to post
-     * @param data Optional user-defined data to post with the score
-     * @param leaderboardType leaderboard type
-     * @param rotationType Type of rotation
-     * @param rotationReset A date Object representing the time and date to start rotation
-     * @param retainedCount How many rotations to keep
-     * @param callback The method to be invoked when the server response is received
+     * @deprecated Use postScoreToDynamicLeaderboardUTC instead - Will be removed on March 1, 2022
      */
     bc.socialLeaderboard.postScoreToDynamicLeaderboard = function(leaderboardName, score,
                                                                                 data, leaderboardType, rotationType, rotationReset, retainedCount, callback ) {
@@ -412,10 +419,72 @@ function BCSocialLeaderboard() {
      * @param rotationType Type of rotation
      * @param rotationReset A date Object representing the time and date to start rotation
      * @param retainedCount How many rotations to keep
+     * @param callback The method to be invoked when the server response is received
+     */
+    bc.socialLeaderboard.postScoreToDynamicLeaderboardUTC = function(leaderboardName, score,
+                                                                     data, leaderboardType, rotationType, 
+                                                                     rotationReset, retainedCount, callback ) {
+        bc.brainCloudManager
+            .sendRequest({
+                service : bc.SERVICE_LEADERBOARD,
+                operation : bc.socialLeaderboard.OPERATION_POST_SCORE_DYNAMIC,
+                data : {
+                    leaderboardId : leaderboardName,
+                    score : score,
+                    data : data,
+                    leaderboardType : leaderboardType,
+                    rotationType : rotationType,
+                    rotationResetTime : rotationReset.getTime().toFixed(0),
+                    retainedCount : retainedCount
+                },
+                callback : callback
+            });
+    };
+
+    /**
+     *@deprecated Use postScoreToDynamicLeaderboardDaysUTC instead - Will be removed on March 1, 2022
+     */
+    bc.socialLeaderboard.postScoreToDynamicLeaderboardDays = function(leaderboardName, score,
+                                                                                    data, leaderboardType, rotationReset, retainedCount, numDaysToRotate, callback ) {
+        bc.brainCloudManager
+            .sendRequest({
+                service : bc.SERVICE_LEADERBOARD,
+                operation : bc.socialLeaderboard.OPERATION_POST_SCORE_DYNAMIC,
+                data : {
+                    leaderboardId : leaderboardName,
+                    score : score,
+                    data : data,
+                    leaderboardType : leaderboardType,
+                    rotationType : "DAYS",
+                    rotationResetTime : rotationReset.getTime().toFixed(0),
+                    retainedCount : retainedCount,
+                    numDaysToRotate : numDaysToRotate
+                },
+                callback : callback
+            });
+    };
+
+    /**
+     * Post the players score to the given social leaderboard.
+     * Pass leaderboard config data to dynamically create if necessary.
+     * You can optionally send a user-defined json string of data
+     * with the posted score. This string could include information
+     * relevant to the posted score.
+     *
+     * Service Name - SocialLeaderboard
+     * Service Operation - PostScoreDynamic
+     *
+     * @param leaderboardName The leaderboard to post to
+     * @param score The score to post
+     * @param data Optional user-defined data to post with the score
+     * @param leaderboardType leaderboard type
+     * @param rotationType Type of rotation
+     * @param rotationReset A date Object representing the time and date to start rotation
+     * @param retainedCount How many rotations to keep
      * @param numDaysToRotate How many days between each rotation
      * @param callback The method to be invoked when the server response is received
      */
-    bc.socialLeaderboard.postScoreToDynamicLeaderboardDays = function(leaderboardName, score,
+    bc.socialLeaderboard.postScoreToDynamicLeaderboardDaysUTC = function(leaderboardName, score,
                                                                                     data, leaderboardType, rotationReset, retainedCount, numDaysToRotate, callback ) {
         bc.brainCloudManager
             .sendRequest({
@@ -769,19 +838,7 @@ function BCSocialLeaderboard() {
     }
 
     /**
-     * Post the group score to the given group leaderboard and dynamically create if necessary. LeaderboardType, rotationType, rotationReset, and retainedCount are required.     *
-     * Service Name - leaderboard
-     * Service Operation - POST_SCORE_TO_DYNAMIC_GROUP_LEADERBOARD
-     *
-     * @param leaderboardId the id of the leaderboard
-     * @param groupId the group's id
-     * @param score the sort order
-     * @param data extra data
-     * @param leaderboardType the type
-     * @param rotationType the type of tournamnet rotation
-     * @param rotationResetTime how often to reset
-     * @param retainedCount 
-     * @param callback The method to be invoked when the server response is received
+     * @deprecated Use postScoreToDynamicGroupLeaderboardUTC instead - Will be removed on March 1 2022
      */
     bc.socialLeaderboard.postScoreToDynamicGroupLeaderboard = function(leaderboardId, groupId, score, data, leaderboardType, rotationType, rotationResetTime, retainedCount, callback) {
         var message = {
@@ -803,6 +860,40 @@ function BCSocialLeaderboard() {
         });
     }
 
+    /**
+     * Post the group score to the given group leaderboard and dynamically create if necessary. LeaderboardType, rotationType, rotationReset, and retainedCount are required.     *
+     * Service Name - leaderboard
+     * Service Operation - POST_SCORE_TO_DYNAMIC_GROUP_LEADERBOARD
+     *
+     * @param leaderboardId the id of the leaderboard
+     * @param groupId the group's id
+     * @param score the sort order
+     * @param data extra data
+     * @param leaderboardType the type
+     * @param rotationType the type of tournamnet rotation
+     * @param rotationResetTime the date to reset the rotation in milliseconds UTC
+     * @param retainedCount 
+     * @param callback The method to be invoked when the server response is received
+     */
+    bc.socialLeaderboard.postScoreToDynamicGroupLeaderboardUTC = function(leaderboardId, groupId, score, data, leaderboardType, rotationType, rotationResetTime, retainedCount, callback) {
+        var message = {
+            leaderboardId : leaderboardId,
+            groupId : groupId,
+            score : score,
+            data : data,
+            leaderboardType : leaderboardType,
+            rotationType : rotationType,
+            rotationResetTime : rotationResetTime,
+            retainedCount : retainedCount
+        };
+
+        bc.brainCloudManager.sendRequest({
+            service : bc.SERVICE_LEADERBOARD,
+            operation : bc.socialLeaderboard.OPERATION_POST_SCORE_TO_DYNAMIC_GROUP_LEADERBOARD,
+            data : message,
+            callback : callback
+        });
+    }
 }
 
 BCSocialLeaderboard.apply(window.brainCloudClient = window.brainCloudClient || {});

--- a/src/brainCloudClient-tournament.js
+++ b/src/brainCloudClient-tournament.js
@@ -215,16 +215,7 @@ function BCTournament() {
     };
 
     /**
-     * Post the users score to the leaderboard
-     *
-     * Service Name - tournament
-     * Service Operation - POST_TOURNAMENT_SCORE
-     *
-     * @param leaderboardId The leaderboard for the tournament
-     * @param score The score to post
-     * @param data Optional data attached to the leaderboard entry
-     * @param roundStartedTime Time the user started the match resulting in the score being posted in UTC.
-     * @param callback The method to be invoked when the server response is received
+     * @deprecated use postTournamentScoreUTC instead. Will be removed on March 1 2022
      */
     bc.tournament.postTournamentScore = function(leaderboardId, score, data, roundStartedTime, callback) {
         var message = {
@@ -247,6 +238,68 @@ function BCTournament() {
      * Post the users score to the leaderboard
      *
      * Service Name - tournament
+     * Service Operation - POST_TOURNAMENT_SCORE
+     *
+     * @param leaderboardId The leaderboard for the tournament
+     * @param score The score to post
+     * @param data Optional data attached to the leaderboard entry
+     * @param roundStartedTime Time the user started the match resulting in the score being posted in UTC.
+     * @param callback The method to be invoked when the server response is received
+     */
+    bc.tournament.postTournamentScoreUTC = function(leaderboardId, score, data, roundStartedTime, callback) {
+        var message = {
+            leaderboardId : leaderboardId,
+            score : score,
+            roundStartedEpoch: roundStartedTime.getTime()
+        };
+
+        if(data) message.data = data;
+
+        bc.brainCloudManager.sendRequest({
+            service : bc.SERVICE_TOURNAMENT,
+            operation : bc.tournament.OPERATION_POST_TOURNAMENT_SCORE,
+            data : message,
+            callback : callback
+        });
+    };
+
+    /**
+     * @deprecated use postTournamentScoreWithResultsUTC instead. Will be removed on March 1 2022
+     */
+    bc.tournament.postTournamentScoreWithResults = function(
+        leaderboardId,
+        score,
+        data,
+        roundStartedTime,
+        sort,
+        beforeCount,
+        afterCount,
+        initialScore,
+        callback) {
+        var message = {
+            leaderboardId : leaderboardId,
+            score : score,
+            roundStartedEpoch: roundStartedTime.getTime(),
+            sort: sort,
+            beforeCount : beforeCount,
+            afterCount : afterCount,
+            initialScore : initialScore
+        };
+
+        if(data) message.data = data;
+
+        bc.brainCloudManager.sendRequest({
+            service : bc.SERVICE_TOURNAMENT,
+            operation : bc.tournament.OPERATION_POST_TOURNAMENT_SCORE_WITH_RESULTS,
+            data : message,
+            callback : callback
+        });
+    };
+
+    /**
+     * Post the users score to the leaderboard
+     *
+     * Service Name - tournament
      * Service Operation - POST_TOURNAMENT_SCORE_WITH_RESULTS
      *
      * @param leaderboardId The leaderboard for the tournament
@@ -260,7 +313,7 @@ function BCTournament() {
      *                          Usually 0, unless leaderboard is LOW_VALUE
      * @param callback The method to be invoked when the server response is received
      */
-    bc.tournament.postTournamentScoreWithResults = function(
+    bc.tournament.postTournamentScoreWithResultsUTC = function(
         leaderboardId,
         score,
         data,

--- a/src/brainCloudClient-user-items.js
+++ b/src/brainCloudClient-user-items.js
@@ -83,6 +83,23 @@ function BCUserItems() {
     };
 
     /**
+     * @deprecated Use getUserItemsPage instead. Will be removed on March 1 2022
+     */
+    bc.userItems.getUserInventoryPage = function(context, includeDef, callback) {
+        var message = {
+            context : context,
+            includeDef : includeDef
+        };
+
+        bc.brainCloudManager.sendRequest({
+            service : bc.SERVICE_USER_ITEMS,
+            operation : bc.userItems.OPERATION_GET_USER_INVENTORY_PAGE,
+            data : message,
+            callback : callback
+        });
+    };
+
+    /**
      * Retrieves the page of user's inventory from the server 
      * based on the context. If includeDef is true, response
      *  includes associated itemDef with each user item, with 
@@ -97,7 +114,7 @@ function BCUserItems() {
      * @param includeDef 
      * @param callback The method to be invoked when the server response is received
      */
-    bc.userItems.getUserInventoryPage = function(context, includeDef, callback) {
+    bc.userItems.getUserItemsPage = function(context, includeDef, callback) {
         var message = {
             context : context,
             includeDef : includeDef
@@ -106,6 +123,24 @@ function BCUserItems() {
         bc.brainCloudManager.sendRequest({
             service : bc.SERVICE_USER_ITEMS,
             operation : bc.userItems.OPERATION_GET_USER_INVENTORY_PAGE,
+            data : message,
+            callback : callback
+        });
+    };
+
+    /**
+     * @deprecated Use getUserItemsPageOffset instead. Will be removed on March 1 2022
+     */
+    bc.userItems.getUserInventoryPageOffset = function(context, pageOffset, includeDef, callback) {
+        var message = {
+            context : context,
+            pageOffset : pageOffset,
+            includeDef : includeDef
+        };
+
+        bc.brainCloudManager.sendRequest({
+            service : bc.SERVICE_USER_ITEMS,
+            operation : bc.userItems.OPERATION_GET_USER_INVENTORY_PAGE_OFFSET,
             data : message,
             callback : callback
         });
@@ -126,7 +161,7 @@ function BCUserItems() {
      * @param includeDef 
      * @param callback The method to be invoked when the server response is received
      */
-    bc.userItems.getUserInventoryPageOffset = function(context, pageOffset, includeDef, callback) {
+    bc.userItems.getUserItemsPageOffset = function(context, pageOffset, includeDef, callback) {
         var message = {
             context : context,
             pageOffset : pageOffset,

--- a/src/brainCloudClient.js
+++ b/src/brainCloudClient.js
@@ -7,6 +7,7 @@ function BrainCloudClient() {
     var bcc = this;
 
     bcc.name = "BrainCloudClient";
+    bcc.appVersion = "1.0";
 
     // If this is not the singleton, initialize it
     if(window.brainCloudClient !== bcc) {
@@ -201,6 +202,8 @@ function BrainCloudClient() {
             return;
         }
 
+        bcc.appVersion = appVersion;
+
         bcc.brainCloudManager.initialize(appId, secret, appVersion);
     };
 
@@ -224,6 +227,8 @@ function BrainCloudClient() {
             console.log("ERROR | Failed to initialize brainCloud - " + error);
             return;
         }
+
+        bcc.appVersion = appVersion;
 
         bcc.brainCloudManager.initializeWithApps(defaultAppId, secretMap, appVersion);
     };
@@ -257,6 +262,15 @@ function BrainCloudClient() {
      */
     bcc.getAppId = function() {
         return bcc.brainCloudManager.getAppId();
+    };
+
+    /**
+     * Returns the app version
+     * 
+     * @return {string} - The application version
+     */
+    bcc.getAppVersion = function() {
+        return bcc.appVersion;
     };
 
     /**
@@ -339,6 +353,13 @@ function BrainCloudClient() {
     };
 
     /**
+     * @deprecated Use registerGlobalErrorCallback() instead - Removal after March 1 2022
+     */
+    bcc.setErrorCallback = function(errorCallback) {
+        bcc.brainCloudManager.setErrorCallback(errorCallback);
+    };
+
+    /**
      * Sets a callback handler for any error messages that come from brainCloud.
      * This will include any networking errors as well as requests from the client
      * which do not register a callback handler.
@@ -346,7 +367,7 @@ function BrainCloudClient() {
      * @param errorCallback
      *            {function} - The error callback
      */
-    bcc.setErrorCallback = function(errorCallback) {
+    bcc.registerGlobalErrorCallback = function(errorCallback) {
         bcc.brainCloudManager.setErrorCallback(errorCallback);
     };
 


### PR DESCRIPTION
readFriendPlayerState -> readFriendUserState
updateEntityUpdateTimeToLive -> updateEntityTimeToLive
mergeGoogleIdentity (duplicate) -> mergeGoogleOpenIdIdentity
detachGoogleIdentity (duplicate) -> detachGoogleOpenIdIdentity
getRTTEnabled -> isRTTEnabled
getGlobalLeaderboardEntryCountByVersion+
postScoreToDynamicLeaderboard -> postScoreToDynamicLeaderboardUTC
postScoreToDynamicLeaderboardDays -> postScoreToDynamicLeaderboardDaysUTC
postScoreToDynamicGroupLeaderboard -> postScoreToDynamicGroupLeaderboardUTC
postTournamentScore -> postTournamentScoreUTC
postTournamentScoreWithResults -> postTournamentScoreWithResultsUTC
getUserInventoryPage -> getUserItemsPage
getUserInventoryPageOffset -> getUserItemsPageOffset
getAppVersion+
setErrorCallback -> registerGlobalErrorCallback