### PR TITLE
Prevent crash if no data object during authentication

### DIFF
--- a/src/brainCloudBase.js
+++ b/src/brainCloudBase.js
@@ -420,7 +420,7 @@ function BrainCloudManager ()
                     bcm._sessionId = "";
                     bcm.authentication.profileId = "";
                 }
-                else if (bcm._inProgressQueue[c].operation == "AUTHENTICATE")
+                else if (data && bcm._inProgressQueue[c].operation == "AUTHENTICATE")
                 {
                     bcm._isAuthenticated = true;
                     if (data.hasOwnProperty("playerSessionExpiry"))


### PR DESCRIPTION
[On Saturday May 21st](https://braincloud.statuspage.io/incidents/kxhknkc2s536), BrainCloud had a service disruption, causing authentication to fail, but that failure caused this node.js script to trigger a crash due to attempting to access the data object when it was null.

Here is an example error log:

```
/usr/src/node_modules/braincloud/lib/brainCloudClient.concat.js:415
                    if (data.hasOwnProperty("playerSessionExpiry"))
                             ^

TypeError: Cannot read property 'hasOwnProperty' of null
    at BrainCloudManager.bcm.handleSuccessResponse (/usr/src/node_modules/braincloud/lib/brainCloudClient.concat.js:415:30)
```

In looking through this file, there's only one `if` conditional that does not have a guard against this, which is the one that caused the crash. So it seems consistent with the existing code to patch this, and prevent service disruptions from causing a NodeJS crash.