### PR TITLE
Debug/endmatch test

### DIFF
--- a/src/brainCloudBase.js
+++ b/src/brainCloudBase.js
@@ -44,7 +44,7 @@ function BrainCloudManager ()
     bcm._inProgressQueue = [];
     bcm._abTestingId = -1;
     bcm._sessionId = "";
-    bcm._packetId = -1;
+    bcm._packetId = 0;
     bcm._loader = null;
     bcm._eventCallback = null;
     bcm._rewardCallback = null;
@@ -150,7 +150,7 @@ function BrainCloudManager ()
         }
         else
         {
-            bcm._packetId = -1; 
+            bcm._packetId = 0; 
         }
         bcm._sessionId = sessionId;
     };
@@ -282,7 +282,7 @@ function BrainCloudManager ()
         bcm._sendQueue = [];
         bcm._inProgressQueue = [];
         bcm._sessionId = "";
-        bcm.packetId = -1;
+        bcm.packetId = 0;
         bcm._isAuthenticated = false;
         bcm._requestInProgress = false;
 

--- a/src/brainCloudRelayComms.js
+++ b/src/brainCloudRelayComms.js
@@ -235,8 +235,6 @@ function BrainCloudRelayComms(_client) {
 
     bcr.onSocketClose = function(e) {
         bcr.disconnect();
-        console.log("endmatch:");
-        console.log(bcr.endMatchRequested);
         if (bcr.connectCallback.failure) {
             bcr.connectCallback.failure("Relay Connection closed");
         }

--- a/src/brainCloudRelayComms.js
+++ b/src/brainCloudRelayComms.js
@@ -178,7 +178,7 @@ function BrainCloudRelayComms(_client) {
     bcr.registerRelayCallback = function(callback) {
         bcr._relayCallback = callback;
     }
-    bcr.deregisterRelayCallback = function() {
+    bcr.RelayCallback = function() {
         bcr._relayCallback = null;
     }
 
@@ -235,6 +235,8 @@ function BrainCloudRelayComms(_client) {
 
     bcr.onSocketClose = function(e) {
         bcr.disconnect();
+        console.log("endmatch:");
+        console.log(bcr.endMatchRequested);
         if (bcr.connectCallback.failure) {
             bcr.connectCallback.failure("Relay Connection closed");
         }

--- a/src/brainCloudRelayComms.js
+++ b/src/brainCloudRelayComms.js
@@ -178,7 +178,7 @@ function BrainCloudRelayComms(_client) {
     bcr.registerRelayCallback = function(callback) {
         bcr._relayCallback = callback;
     }
-    bcr.RelayCallback = function() {
+    bcr.deregisterRelayCallback = function() {
         bcr._relayCallback = null;
     }
 

--- a/test/test.js
+++ b/test/test.js
@@ -6292,11 +6292,11 @@ async function testRelay() {
     })
 
     // // Full flow. Create lobby -> ready up -> connect to server
-    await asyncTest("connect()", 8, () =>
+    await asyncTest("connect()", 9, () =>
     {
         // Determines whether callback has already occured
-        let systemCallback = false;
-        let relayCallback = false;
+        //let systemCallback = false;
+        //let relayCallback = false;
 
         let endMatch = false;
 
@@ -6316,7 +6316,7 @@ async function testRelay() {
             {
                 ok(netId == bc.relay.getNetIdForProfileId(UserA.profileId) && data.toString('ascii') == "Echo", "Relay callback")
                 
-                relayCallback = true;
+                //relayCallback = true;
 
                 // Send end match request
                 var json = {
@@ -6324,13 +6324,13 @@ async function testRelay() {
                 }
                 bc.relay.endMatch(json);
                 
-                resolve_test();
+                //resolve_test();
             }
         })
 
         bc.relay.registerSystemCallback(json =>
         {
-            if (json.op == "CONNECT" && systemCallback == false)
+            if (json.op == "CONNECT" /*&& systemCallback == false*/)
             {
                 ok(true, "System Callback")
                 let relayOwnerCxId = bc.relay.getOwnerCxId()
@@ -6338,7 +6338,7 @@ async function testRelay() {
                 let netId = bc.relay.getNetIdForProfileId(UserA.profileId)
                 ok(UserA.profileId == bc.relay.getProfileIdForNetId(netId), "getNetIdForProfileId and getProfileIdForNetId")
                 
-                systemCallback = true;
+                //systemCallback = true;
                 
                 // Wait 5sec then check the ping.
                 // If we are pinging properly, we should get
@@ -6358,6 +6358,8 @@ async function testRelay() {
                 ok(true, "End Match");
 
                 endMatch = true;
+
+                resolve_test();
             }
         })
 

--- a/test/test.js
+++ b/test/test.js
@@ -6312,8 +6312,8 @@ async function testRelay() {
 
         bc.relay.registerRelayCallback((netId, data) =>
         {
-            if(relayCallback == false)
-            {
+            //if(relayCallback == false)
+            //{
                 ok(netId == bc.relay.getNetIdForProfileId(UserA.profileId) && data.toString('ascii') == "Echo", "Relay callback")
                 
                 //relayCallback = true;
@@ -6325,7 +6325,7 @@ async function testRelay() {
                 bc.relay.endMatch(json);
                 
                 //resolve_test();
-            }
+            //}
         })
 
         bc.relay.registerSystemCallback(json =>

--- a/test/test.js
+++ b/test/test.js
@@ -6292,7 +6292,7 @@ async function testRelay() {
     })
 
     // // Full flow. Create lobby -> ready up -> connect to server
-    await asyncTest("connect()", 9, () =>
+    await asyncTest("connect()", 10, () =>
     {
         // Determines whether callback has already occured
         //let systemCallback = false;
@@ -6359,7 +6359,7 @@ async function testRelay() {
 
                 endMatch = true;
 
-                resolve_test();
+                //resolve_test();
             }
         })
 
@@ -6386,8 +6386,18 @@ async function testRelay() {
                         ok(true, "Relay Connected")
                     }, error =>
                     {
-                        ok(false, error);
-                        resolve_test();
+                        // End match req closes socket which causes error ("Relay Connection Closed") but this is expected
+                        if(endMatch){
+                            ok(true, error); 
+                            resolve_test(); // Successful test ends here
+                        }
+                        else{   // If any other connectCallback fails that is a problem
+                            ok(false, error);
+                            resolve_test();
+                        }
+
+                       // ok(false, error);
+                        //resolve_test();
                     })
                 }
                 else

--- a/test/test.js
+++ b/test/test.js
@@ -6295,8 +6295,6 @@ async function testRelay() {
     await asyncTest("connect()", 10, () =>
     {
         // Determines whether callback has already occured
-        //let systemCallback = false;
-        //let relayCallback = false;
 
         let endMatch = false;
 
@@ -6312,33 +6310,24 @@ async function testRelay() {
 
         bc.relay.registerRelayCallback((netId, data) =>
         {
-            //if(relayCallback == false)
-            //{
-                ok(netId == bc.relay.getNetIdForProfileId(UserA.profileId) && data.toString('ascii') == "Echo", "Relay callback")
-                
-                //relayCallback = true;
+            ok(netId == bc.relay.getNetIdForProfileId(UserA.profileId) && data.toString('ascii') == "Echo", "Relay callback")
 
-                // Send end match request
-                var json = {
-                    "op" : "END_MATCH"
-                }
-                bc.relay.endMatch(json);
-                
-                //resolve_test();
-            //}
+            // Send end match request
+            var json = {
+                "op" : "END_MATCH"
+            }
+            bc.relay.endMatch(json);
         })
 
         bc.relay.registerSystemCallback(json =>
         {
-            if (json.op == "CONNECT" /*&& systemCallback == false*/)
+            if (json.op == "CONNECT")
             {
                 ok(true, "System Callback")
                 let relayOwnerCxId = bc.relay.getOwnerCxId()
                 ok(ownerCxId == relayOwnerCxId, `getOwnerCxId: ${ownerCxId} == ${relayOwnerCxId}`)
                 let netId = bc.relay.getNetIdForProfileId(UserA.profileId)
                 ok(UserA.profileId == bc.relay.getProfileIdForNetId(netId), "getNetIdForProfileId and getProfileIdForNetId")
-                
-                //systemCallback = true;
                 
                 // Wait 5sec then check the ping.
                 // If we are pinging properly, we should get
@@ -6358,8 +6347,6 @@ async function testRelay() {
                 ok(true, "End Match");
 
                 endMatch = true;
-
-                //resolve_test();
             }
         })
 
@@ -6395,9 +6382,6 @@ async function testRelay() {
                             ok(false, error);
                             resolve_test();
                         }
-
-                       // ok(false, error);
-                        //resolve_test();
                     })
                 }
                 else


### PR DESCRIPTION
- Changed packetId from -1 to 0 to sync with other libs
- Modified endmatch test functionality so that it no longer throws false fails
    - Test was ending before the end match process was completed so on complete, it would throw a fail
    - It is now extended to wait for the process to complete