### PR TITLE
Bcloud 9481 refactor identity tests

### DIFF
--- a/src/brainCloudClient-identity.js
+++ b/src/brainCloudClient-identity.js
@@ -193,8 +193,8 @@ function BCIdentity() {
             authenticationToken : ids.authenticationToken
         }
 
-        if (externalAuthName) {
-            data["externalAuthName"] = externalAuthName;
+        if (ids.authenticationSubType !== null || ids.authenticationSubType !== "") {
+            data["externalAuthName"] = ids.authenticationSubType;
         };
 
         if (extraJson) {
@@ -229,8 +229,8 @@ function BCIdentity() {
             authenticationToken : ids.authenticationToken
         }
 
-        if (externalAuthName) {
-            data["externalAuthName"] = externalAuthName;
+        if (ids.authenticationSubType !== null || ids.authenticationSubType !== "") {
+            data["externalAuthName"] = ids.authenticationSubType;
         };
 
         if (extraJson) {

--- a/src/brainCloudClient-identity.js
+++ b/src/brainCloudClient-identity.js
@@ -30,6 +30,7 @@ function BCIdentity() {
     bc.identity.OPERATION_SWITCH_TO_PARENT_PROFILE = "SWITCH_TO_PARENT_PROFILE";
     bc.identity.OPERATION_GET_CHILD_PROFILES = "GET_CHILD_PROFILES";
     bc.identity.OPERATION_GET_IDENTITIES = "GET_IDENTITIES";
+    bc.identity.OPERATION_GET_IDENTITY_STATUS = "GET_IDENTITY_STATUS";
     bc.identity.OPERATION_GET_EXPIRED_IDENTITIES = "GET_EXPIRED_IDENTITIES";
     bc.identity.OPERATION_REFRESH_IDENTITY = "REFRESH_IDENTITY";
     bc.identity.OPERATION_CHANGE_EMAIL_IDENTITY = "CHANGE_EMAIL_IDENTITY";
@@ -997,6 +998,18 @@ function BCIdentity() {
 			callback: callback
 		});
 	};
+
+    bc.identity.getIdentityStatus = function(authenticationType, externalAuthName, callback) {
+        bc.brainCloudManager.sendRequest({
+            service: bc.SERVICE_IDENTITY,
+            operation: bc.identity.OPERATION_GET_IDENTITY_STATUS,
+            data: {
+                authenticationType: authenticationType,
+                externalAuthName: externalAuthName
+            },
+            callback: callback
+        })
+    }
 
 	/**
 	 * Retrieve list of expired identities

--- a/src/brainCloudClient-identity.js
+++ b/src/brainCloudClient-identity.js
@@ -999,6 +999,12 @@ function BCIdentity() {
 		});
 	};
 
+    /**
+     * Retrieves identity status for given identity type for this profile.
+     * @param  authenticationType Type of authentication
+     * @param  externalAuthName The name of the external authentication mechanism (optional, used for custom authentication types)
+     * @param  callback The method to be invoked when the server response is received
+     */
     bc.identity.getIdentityStatus = function(authenticationType, externalAuthName, callback) {
         bc.brainCloudManager.sendRequest({
             service: bc.SERVICE_IDENTITY,

--- a/test/package-lock.json
+++ b/test/package-lock.json
@@ -20,7 +20,7 @@
     },
     "../deploy/node": {
       "name": "braincloud",
-      "version": "5.3.0",
+      "version": "5.4.1",
       "license": "Apache-2.0",
       "dependencies": {
         "buffer": "^6.0.3",

--- a/test/test.js
+++ b/test/test.js
@@ -3219,7 +3219,7 @@ async function testGroup() {
 }
 
 // TODO:  Create new Identity Service test
-async function testNewIdentity() {
+async function testIdentity() {
     bc.brainCloudClient.setDebugEnabled(true);
 
     bc.initialize(GAME_ID, SECRET, GAME_VERSION);
@@ -3363,63 +3363,58 @@ async function testNewIdentity() {
     });
 
     // TODO:  AttachParentWithIdentity
-    // TODO:  40301 error on attach: The brainCloud library was initialized with an incorrect secret.
-    // await asyncTest("testAttachDetachParentWithIdentity()", 7, function () {
+    await asyncTest("testAttachDetachParentWithIdentity()", 3, function () {
 
-    //     //bc.resetStoredProfileId();
+        //bc.resetStoredProfileId();
+        initializeClient()
 
-    //     var externalId = parentUniversalId;
-    //     var authenticationToken = password;
-    //     var authenticationType = bc.identity.authenticationType.universal
-    //     var externalAuthName = null;
-    //     var forceCreate = true;
+        var externalId = parentUniversalId;
+        var authenticationToken = password;
+        var authenticationType = bc.identity.authenticationType.universal
+        var externalAuthName = null;
+        var forceCreate = true;
 
-    //     bc.authenticateAnonymous(function (authResponse) {
-    //         if (authResponse.status === 200) {
+        bc.authenticateAnonymous(function (authResponse) {
+            if (authResponse.status === 200) {
 
-    //             // Switch to Child
-    //             bc.identity.switchToChildProfile(null, CHILD_APP_ID, true, (switchToChildResponse) => {
-    //                 ok(true, JSON.stringify(switchToChildResponse));
-    //                 equal(switchToChildResponse.status, 200, "Expecting 200");
+                // Switch to Child
+                bc.identity.switchToChildProfile(null, CHILD_APP_ID, true, (switchToChildResponse) => {
+                    equal(switchToChildResponse.status, 200, "Expecting 200");
 
-    //                 // Attach
-    //                 bc.identity.attachParentWithIdentity(externalId, authenticationToken, authenticationType, externalAuthName, forceCreate, (attachResponse) => {
-    //                     ok(true, JSON.stringify(attachResponse));
-    //                     equal(attachResponse.status, 200, "Expecting 200");
+                    bc.identity.detachParent(detachResponse => {
+                        equal(detachResponse.status, 200, " expecting successful detach")
 
-    //                     // Detach
-    //                     bc.identity.detachParent((detachResponse) => {
-    //                         ok(true, JSON.stringify(detachResponse));
-    //                         equal(detachResponse.status, 200, "Expecting 200");
+                        // Attach
+                        bc.identity.attachParentWithIdentity(externalId, authenticationToken, authenticationType, externalAuthName, forceCreate, (attachResponse) => {
+                            equal(attachResponse.status, 200, "Expecting 200");
 
-    //                         bc.playerState.logout((logoutResponse) => {
-    //                             equal(logoutResponse.status, 200, "Expecting 200");
-    //                             resolve_test();
-    //                         });
-    //                     });
-    //                 });
-    //             });
-    //         }
-    //         else {
-    //             console.log("fail")
-    //             resolve_test()
-    //         }
-    //     });
-    // });
+                            bc.playerState.logout(() => {
+                                resolve_test();
+                            });
+                        });
+                    })
+                })
+            }
+            else {
+                console.log("fail")
+                resolve_test()
+            }
+        });
+    });
 
     // TODO:  AttachParseIdentity
 
     // AttachPeerProfile
     await asyncTest("testAttachDetachPeerProfile()", 3, function () {
 
-        bc.resetStoredProfileId();
+        initializeClient()
 
-        bc.authenticateAnonymous(function (authResponse) {
+        bc.authenticateUniversal(UserA.name, UserA.password, true, function (authResponse) {
             if (authResponse.status === 200) {
-                var authenticationType = bc.identity.authenticationType.email;
+                var authenticationType = bc.identity.authenticationType.universal;
                 var externalAuthName = "";
 
-                bc.identity.attachPeerProfile(PEER_NAME, peerExternalId, password, authenticationType, externalAuthName, true, (attachResponse) => {
+                bc.identity.attachPeerProfile(PEER_NAME, UserA.name + "_peer", password, authenticationType, externalAuthName, true, (attachResponse) => {
                     equal(attachResponse.status, 200, "Expecting Successful Attach");
 
                     bc.identity.detachPeer(PEER_NAME, (detachResponse) => {
@@ -3742,124 +3737,6 @@ async function testNewIdentity() {
         })
     })
 }
-
-////////////////////////////////////////
-// Identity tests
-////////////////////////////////////////
-// TODO:  remove this test once NewIdentity is confirmed
-// async function testIdentity() {
-//     if (!module("Identity", () =>
-//     {
-//         return setUpWithAuthenticate();
-//     }, () =>
-//     {
-//         return tearDownLogout();
-//     })) return;
-
-//     await asyncTest("attachBlockchainIdentity()", 2, function() {
-//         bc.identity.attachBlockchainIdentity("config",
-//                 "thisisAgreattestKey", function(result) {
-//                     ok(true, JSON.stringify(result));
-//                     equal(result.status, 200, "Expecting 200");
-//                     resolve_test();
-//                 });
-//     });
-
-//     await asyncTest("detachBlockchainIdentity()", 2, function() {
-//         bc.identity.detachBlockchainIdentity("config",
-//                     function(result) {
-//                     ok(true, JSON.stringify(result));
-//                     equal(result.status, 200, "Expecting 200");
-//                     resolve_test();
-//                 });
-//     });
-
-//     await asyncTest("attachFacebookId()", 2, function() {
-//         bc.identity.attachFacebookIdentity("test",
-//                 "3780516b-14f8-4055-8899-8eaab6ac7e82", function(result) {
-//                     ok(true, JSON.stringify(result));
-//                     nequal(result.status, 200, "Expecting failure");
-//                     resolve_test();
-//                 });
-//     });
-
-//     await asyncTest("mergeFacebookId()", 2, function() {
-//         bc.identity.mergeFacebookIdentity("test",
-//                 "3780516b-14f8-4055-8899-8eaab6ac7e82", function(result) {
-//                     ok(true, JSON.stringify(result));
-//                     equal(result.status, 202, "Expecting 202");
-//                     resolve_test();
-//                 });
-//     });
-
-//     await asyncTest("detachFacebookId()", 2, function() {
-//         bc.identity.detachFacebookIdentity("test", true,
-//                 function(result) {
-//                     ok(true, JSON.stringify(result));
-//                     equal(result.status, 202, "Expecting 202");
-//                     resolve_test();
-//                 });
-//     });
-
-//     await asyncTest("getIdentities()", 2, function() {
-//         bc.identity.getIdentities(
-//                 function(result) {
-//                     ok(true, JSON.stringify(result));
-//                     equal(result.status, 200, "Expecting 200");
-//                     resolve_test();
-//                 });
-//     });
-
-//     await asyncTest("getExpiredIdentities()", 2, function() {
-//         bc.identity.getExpiredIdentities(
-//                 function(result) {
-//                     ok(true, JSON.stringify(result));
-//                     equal(result.status, 200, "Expecting 200");
-//                     resolve_test();
-//                 });
-//     });
-
-//     await asyncTest("refreshIdentity()", 3, function() {
-//         bc.identity.refreshIdentity(
-//                 UserA.name,
-//                 UserA.password,
-//                 bc.identity.authenticationType.universal,
-//                 function(result) {
-//                     ok(true, JSON.stringify(result));
-//                     equal(result.status, 400, "Expecting 400");
-//                     equal(result.reason_code, 40464, "Expecting 40464");
-//                     resolve_test();
-//                 });
-//     });
-
-//     await asyncTest("attachEmailIdentity()", 2, function() {
-//         bc.identity.attachEmailIdentity(UserC.email,
-//             UserC.password,
-//             function(result) {
-//                     ok(true, JSON.stringify(result));
-//                     equal(result.status, 200, "Expecting 200");
-//                     resolve_test();
-//                 });
-//     });
-
-//     await asyncTest("changeEmailIdentity()", 2, function() {
-
-//         let newEmail = "test_" + getRandomInt(0,1000000) + "@test.getbraincloud.com";
-
-//         bc.identity.changeEmailIdentity(
-//                 UserC.email,
-//                 UserC.password,
-//                 newEmail,
-//                 true,
-//                 function(result) {
-//                     ok(true, JSON.stringify(result));
-//                     equal(result.status, 200, "Expecting 200");
-//                     resolve_test();
-//                 });
-
-//     });
-// }
-
 
 ////////////////////////////////////////
 // Mail tests
@@ -6015,162 +5892,6 @@ async function testTournament() {
 }
 
 ////////////////////////////////////////
-// Shared Identity tests
-////////////////////////////////////////
-// TODO:  remove this test once new identity is confirmed
-// async function testSharedIdentity() {
-
-
-//     // TODO:  remove following tests after refactoring
-
-//     initializeClient();
-
-//     if (!module("SharedIdentity", null, null)) return;
-
-//     var currencyType = "credits";
-//     var scriptName = "testScript";
-//     var scriptData = { "testParam1" : 1 };
-
-//     await asyncTest("authenticateUniversal()", function() {
-//         bc.brainCloudClient.authentication.authenticateUniversal(UserA.name,
-//                 UserA.password, true, function(result) {
-//                     equal(result.status, 200, JSON.stringify(result));
-//                     resolve_test();
-//                 });
-//     });
-
-//     await asyncTest("switchToChildProfile()", 2, function() {
-//         bc.identity.switchToChildProfile(null,
-//                 CHILD_APP_ID,
-//                 true,
-//                 function(result) {
-//                     ok(true, JSON.stringify(result));
-//                     equal(result.status, 200, "Expecting 200");
-//                     resolve_test();
-//                 });
-//     });
-
-//     await asyncTest("switchToParentProfile()", 2, function() {
-//         bc.identity.switchToParentProfile(PARENT_LEVEL_NAME,
-//                 function(result) {
-//                     ok(true, JSON.stringify(result));
-//                     equal(result.status, 200, "Expecting 200");
-//                     resolve_test();
-//                 });
-//     });
-
-//     await asyncTest("getChildProfiles()", 2, function() {
-//         bc.identity.getChildProfiles(true,
-//                 function(result) {
-//                     ok(true, JSON.stringify(result));
-//                     equal(result.status, 200, "Expecting 200");
-//                     resolve_test();
-//                 });
-//     });
-
-//     await asyncTest("switchToSingletonChildProfile()", 2, function() {
-//         bc.identity.switchToSingletonChildProfile(
-//                 CHILD_APP_ID,
-//                 true,
-//                 function(result) {
-//                     ok(true, JSON.stringify(result));
-//                     equal(result.status, 200, "Expecting 200");
-//                     resolve_test();
-//                 });
-//     });
-
-//     await asyncTest("runParentScript()", 2, function() {
-//         bc.script.runParentScript(scriptName,
-//                 scriptData, PARENT_LEVEL_NAME, function(result) {
-//                     ok(true, JSON.stringify(result));
-//                     equal(result.status, 200, "Expecting 200");
-//                     resolve_test();
-//                 });
-//     });
-
-//     await asyncTest("detachParent()", 2, function() {
-//         bc.identity.detachParent(function(result) {
-//                     ok(true, JSON.stringify(result));
-//                     equal(result.status, 200, "Expecting 200");
-//                     resolve_test();
-//                 });
-//     });
-
-//     await asyncTest("attachParentWithIdentity()", 2, function() {
-//         bc.identity.attachParentWithIdentity(
-//             UserA.name, UserA.password,
-//             bc.identity.authenticationType.universal,
-//             null, true,
-//             function(result) {
-//                     ok(true, JSON.stringify(result));
-//                     equal(result.status, 200, "Expecting 200");
-//                     resolve_test();
-//                 });
-//     });
-
-//     await asyncTest("switchToParentProfile()", 2, function() {
-//         bc.identity.switchToParentProfile(PARENT_LEVEL_NAME,
-//                 function(result) {
-//                     ok(true, JSON.stringify(result));
-//                     equal(result.status, 200, "Expecting 200");
-//                     resolve_test();
-//                 });
-//     });
-
-//     await asyncTest("attachPeerProfile()", 2, function() {
-//         bc.identity.attachPeerProfile(
-//             PEER_NAME,UserA.name, UserA.password,
-//             bc.identity.authenticationType.universal,
-//                 null, true,
-//             function(result) {
-//                     ok(true, JSON.stringify(result));
-//                     equal(result.status, 200, "Expecting 200");
-//                     resolve_test();
-//                 });
-//     });
-
-//     await asyncTest("detachPeer()", 2, function() {
-//         bc.identity.detachPeer(
-//             PEER_NAME,
-//             function(result) {
-//                     ok(true, JSON.stringify(result));
-//                     equal(result.status, 200, "Expecting 200");
-//                     resolve_test();
-//                 });
-//     });
-
-//     await asyncTest("getPeerProfiles()", 2, function() {
-//         bc.identity.getPeerProfiles(
-//             function(result) {
-//                     ok(true, JSON.stringify(result));
-//                     equal(result.status, 200, "Expecting 200");
-//                     resolve_test();
-//                 });
-//     });
-
-//     await asyncTest("logout()", function() {
-//         bc.playerState.logout(function(result) {
-//             equal(result.status, 200, JSON.stringify(result));
-//             resolve_test();
-//         });
-//     });
-
-//     await asyncTest("attachNonLoginUniversalId()", function() {
-//         bc.identity.attachNonLoginUniversalId("braincloudtest@test.getbraincloud.com", function(result) {
-//             equal(result.status, 403, JSON.stringify(result));
-//             resolve_test();
-//         });
-//     });
-
-//     await asyncTest("updateUniversalLoginId()", function() {
-//         bc.identity.updateUniversalIdLogin("braincloudtest@test.getbraincloud.com", function(result) {
-//             equal(result.status, 403, JSON.stringify(result));
-//             resolve_test();
-//         });
-//     });
-// }
-
-////////////////////////////////////////
 // Comms tests
 ////////////////////////////////////////
 async function testComms() {
@@ -8196,8 +7917,7 @@ async function run_tests()
     await testGlobalEntity();
     await testGroupFile();
     await testGroup();
-    //await testIdentity();     // TODO
-    await testNewIdentity();    // TODO
+    await testIdentity();
     await testMail();
     await testMatchMaking();
     await testOneWayMatch();
@@ -8216,7 +7936,6 @@ async function run_tests()
     await testSocialLeaderboard();
     await testTime();
     await testTournament();
-    //await testSharedIdentity(); // TODO
     await testFile();
     await testChat();
     await testMessaging();

--- a/test/test.js
+++ b/test/test.js
@@ -3241,41 +3241,37 @@ async function testNewIdentity() {
 
     // TODO:  All Identity Service APIs per API DOCS
 
-    // TODO:  AttachAdvancedIdentity
-    // TODO:  bug in attachAdvancedIdentity - undefined "externalAuthName"
-    //        should be checking if ids.authenticationSubType instead of if externalAuthName
-    // await asyncTest("testAttachDetacAdvancedIdentity()", 4, function () {
+    // AttachAdvancedIdentity
+    await asyncTest("testAttachDetacAdvancedIdentity()", 4, function () {
 
-    //     bc.resetStoredProfileId();
+        bc.resetStoredProfileId();
 
-    //     var authenticationType = bc.brainCloudClient.authentication.AUTHENTICATION_TYPE_UNIVERSAL;
-    //     var ids = { externalId: universalId, authenticationToken: password, authenticationSubType: "" };
-    //     var forceCreate = true;
-    //     var extraJson = { "key": "value" };
+        var authenticationType = bc.brainCloudClient.authentication.AUTHENTICATION_TYPE_UNIVERSAL;
+        var ids = { externalId: universalId + "Advanced", authenticationToken: password, authenticationSubType: "" };
+        var extraJson = { "key": "value" };
 
-    //     bc.authenticateAnonymous(function (authResponse) {
-    //         if (authResponse.status === 200) {
-    //             console.log("success")
-    //             bc.identity.attachAdvancedIdentity(authenticationType, ids, forceCreate, extraJson, (attachResponse) => {
-    //                 ok(true, JSON.stringify(attachResponse));
-    //                 equal(attachResponse.status, 200, "Expecting 200");
+        bc.authenticateAnonymous(function (authResponse) {
+            if (authResponse.status === 200) {
+                console.log("success")
+                bc.identity.attachAdvancedIdentity(authenticationType, ids, extraJson, (attachResponse) => {
+                    ok(true, JSON.stringify(attachResponse));
+                    equal(attachResponse.status, 200, "Expecting 200");
 
-    //                 bc.identity.detachAdvancedIdentity(authenticationType, ids, forceCreate, extraJson, (detachResponse) => {
-    //                     ok(true, JSON.stringify(detachResponse));
-    //                     equal(detachResponse.status, 200, "Expecting 200");
-    //                     resolve_test();
-    //                 });
-    //             });
-    //         }
-    //         else {
-    //             console.log("fail")
-    //             resolve_test()
-    //         }
-    //     });
-    // });
+                    bc.identity.detachAdvancedIdentity(authenticationType, universalId + "Advanced", true, extraJson, (detachResponse) => {
+                        ok(true, JSON.stringify(detachResponse));
+                        equal(detachResponse.status, 200, "Expecting 200");
+                        resolve_test();
+                    });
+                });
+            }
+            else {
+                console.log("fail")
+                resolve_test()
+            }
+        });
+    });
 
     // TODO:  AttachAppleIdentity
-
 
     // AttachBlockchainIdentity
     await asyncTest("testAttachDetachBlockchainIdentity()", 5, function () {
@@ -3750,118 +3746,119 @@ async function testNewIdentity() {
 ////////////////////////////////////////
 // Identity tests
 ////////////////////////////////////////
-async function testIdentity() {
-    if (!module("Identity", () =>
-    {
-        return setUpWithAuthenticate();
-    }, () =>
-    {
-        return tearDownLogout();
-    })) return;
+// TODO:  remove this test once NewIdentity is confirmed
+// async function testIdentity() {
+//     if (!module("Identity", () =>
+//     {
+//         return setUpWithAuthenticate();
+//     }, () =>
+//     {
+//         return tearDownLogout();
+//     })) return;
 
-    await asyncTest("attachBlockchainIdentity()", 2, function() {
-        bc.identity.attachBlockchainIdentity("config",
-                "thisisAgreattestKey", function(result) {
-                    ok(true, JSON.stringify(result));
-                    equal(result.status, 200, "Expecting 200");
-                    resolve_test();
-                });
-    });
+//     await asyncTest("attachBlockchainIdentity()", 2, function() {
+//         bc.identity.attachBlockchainIdentity("config",
+//                 "thisisAgreattestKey", function(result) {
+//                     ok(true, JSON.stringify(result));
+//                     equal(result.status, 200, "Expecting 200");
+//                     resolve_test();
+//                 });
+//     });
 
-    await asyncTest("detachBlockchainIdentity()", 2, function() {
-        bc.identity.detachBlockchainIdentity("config",
-                    function(result) {
-                    ok(true, JSON.stringify(result));
-                    equal(result.status, 200, "Expecting 200");
-                    resolve_test();
-                });
-    });
+//     await asyncTest("detachBlockchainIdentity()", 2, function() {
+//         bc.identity.detachBlockchainIdentity("config",
+//                     function(result) {
+//                     ok(true, JSON.stringify(result));
+//                     equal(result.status, 200, "Expecting 200");
+//                     resolve_test();
+//                 });
+//     });
 
-    await asyncTest("attachFacebookId()", 2, function() {
-        bc.identity.attachFacebookIdentity("test",
-                "3780516b-14f8-4055-8899-8eaab6ac7e82", function(result) {
-                    ok(true, JSON.stringify(result));
-                    nequal(result.status, 200, "Expecting failure");
-                    resolve_test();
-                });
-    });
+//     await asyncTest("attachFacebookId()", 2, function() {
+//         bc.identity.attachFacebookIdentity("test",
+//                 "3780516b-14f8-4055-8899-8eaab6ac7e82", function(result) {
+//                     ok(true, JSON.stringify(result));
+//                     nequal(result.status, 200, "Expecting failure");
+//                     resolve_test();
+//                 });
+//     });
 
-    await asyncTest("mergeFacebookId()", 2, function() {
-        bc.identity.mergeFacebookIdentity("test",
-                "3780516b-14f8-4055-8899-8eaab6ac7e82", function(result) {
-                    ok(true, JSON.stringify(result));
-                    equal(result.status, 202, "Expecting 202");
-                    resolve_test();
-                });
-    });
+//     await asyncTest("mergeFacebookId()", 2, function() {
+//         bc.identity.mergeFacebookIdentity("test",
+//                 "3780516b-14f8-4055-8899-8eaab6ac7e82", function(result) {
+//                     ok(true, JSON.stringify(result));
+//                     equal(result.status, 202, "Expecting 202");
+//                     resolve_test();
+//                 });
+//     });
 
-    await asyncTest("detachFacebookId()", 2, function() {
-        bc.identity.detachFacebookIdentity("test", true,
-                function(result) {
-                    ok(true, JSON.stringify(result));
-                    equal(result.status, 202, "Expecting 202");
-                    resolve_test();
-                });
-    });
+//     await asyncTest("detachFacebookId()", 2, function() {
+//         bc.identity.detachFacebookIdentity("test", true,
+//                 function(result) {
+//                     ok(true, JSON.stringify(result));
+//                     equal(result.status, 202, "Expecting 202");
+//                     resolve_test();
+//                 });
+//     });
 
-    await asyncTest("getIdentities()", 2, function() {
-        bc.identity.getIdentities(
-                function(result) {
-                    ok(true, JSON.stringify(result));
-                    equal(result.status, 200, "Expecting 200");
-                    resolve_test();
-                });
-    });
+//     await asyncTest("getIdentities()", 2, function() {
+//         bc.identity.getIdentities(
+//                 function(result) {
+//                     ok(true, JSON.stringify(result));
+//                     equal(result.status, 200, "Expecting 200");
+//                     resolve_test();
+//                 });
+//     });
 
-    await asyncTest("getExpiredIdentities()", 2, function() {
-        bc.identity.getExpiredIdentities(
-                function(result) {
-                    ok(true, JSON.stringify(result));
-                    equal(result.status, 200, "Expecting 200");
-                    resolve_test();
-                });
-    });
+//     await asyncTest("getExpiredIdentities()", 2, function() {
+//         bc.identity.getExpiredIdentities(
+//                 function(result) {
+//                     ok(true, JSON.stringify(result));
+//                     equal(result.status, 200, "Expecting 200");
+//                     resolve_test();
+//                 });
+//     });
 
-    await asyncTest("refreshIdentity()", 3, function() {
-        bc.identity.refreshIdentity(
-                UserA.name,
-                UserA.password,
-                bc.identity.authenticationType.universal,
-                function(result) {
-                    ok(true, JSON.stringify(result));
-                    equal(result.status, 400, "Expecting 400");
-                    equal(result.reason_code, 40464, "Expecting 40464");
-                    resolve_test();
-                });
-    });
+//     await asyncTest("refreshIdentity()", 3, function() {
+//         bc.identity.refreshIdentity(
+//                 UserA.name,
+//                 UserA.password,
+//                 bc.identity.authenticationType.universal,
+//                 function(result) {
+//                     ok(true, JSON.stringify(result));
+//                     equal(result.status, 400, "Expecting 400");
+//                     equal(result.reason_code, 40464, "Expecting 40464");
+//                     resolve_test();
+//                 });
+//     });
 
-    await asyncTest("attachEmailIdentity()", 2, function() {
-        bc.identity.attachEmailIdentity(UserC.email,
-            UserC.password,
-            function(result) {
-                    ok(true, JSON.stringify(result));
-                    equal(result.status, 200, "Expecting 200");
-                    resolve_test();
-                });
-    });
+//     await asyncTest("attachEmailIdentity()", 2, function() {
+//         bc.identity.attachEmailIdentity(UserC.email,
+//             UserC.password,
+//             function(result) {
+//                     ok(true, JSON.stringify(result));
+//                     equal(result.status, 200, "Expecting 200");
+//                     resolve_test();
+//                 });
+//     });
 
-    await asyncTest("changeEmailIdentity()", 2, function() {
+//     await asyncTest("changeEmailIdentity()", 2, function() {
 
-        let newEmail = "test_" + getRandomInt(0,1000000) + "@test.getbraincloud.com";
+//         let newEmail = "test_" + getRandomInt(0,1000000) + "@test.getbraincloud.com";
 
-        bc.identity.changeEmailIdentity(
-                UserC.email,
-                UserC.password,
-                newEmail,
-                true,
-                function(result) {
-                    ok(true, JSON.stringify(result));
-                    equal(result.status, 200, "Expecting 200");
-                    resolve_test();
-                });
+//         bc.identity.changeEmailIdentity(
+//                 UserC.email,
+//                 UserC.password,
+//                 newEmail,
+//                 true,
+//                 function(result) {
+//                     ok(true, JSON.stringify(result));
+//                     equal(result.status, 200, "Expecting 200");
+//                     resolve_test();
+//                 });
 
-    });
-}
+//     });
+// }
 
 
 ////////////////////////////////////////
@@ -6020,157 +6017,158 @@ async function testTournament() {
 ////////////////////////////////////////
 // Shared Identity tests
 ////////////////////////////////////////
-async function testSharedIdentity() {
+// TODO:  remove this test once new identity is confirmed
+// async function testSharedIdentity() {
 
 
-    // TODO:  remove following tests after refactoring
+//     // TODO:  remove following tests after refactoring
 
-    initializeClient();
+//     initializeClient();
 
-    if (!module("SharedIdentity", null, null)) return;
+//     if (!module("SharedIdentity", null, null)) return;
 
-    var currencyType = "credits";
-    var scriptName = "testScript";
-    var scriptData = { "testParam1" : 1 };
+//     var currencyType = "credits";
+//     var scriptName = "testScript";
+//     var scriptData = { "testParam1" : 1 };
 
-    await asyncTest("authenticateUniversal()", function() {
-        bc.brainCloudClient.authentication.authenticateUniversal(UserA.name,
-                UserA.password, true, function(result) {
-                    equal(result.status, 200, JSON.stringify(result));
-                    resolve_test();
-                });
-    });
+//     await asyncTest("authenticateUniversal()", function() {
+//         bc.brainCloudClient.authentication.authenticateUniversal(UserA.name,
+//                 UserA.password, true, function(result) {
+//                     equal(result.status, 200, JSON.stringify(result));
+//                     resolve_test();
+//                 });
+//     });
 
-    await asyncTest("switchToChildProfile()", 2, function() {
-        bc.identity.switchToChildProfile(null,
-                CHILD_APP_ID,
-                true,
-                function(result) {
-                    ok(true, JSON.stringify(result));
-                    equal(result.status, 200, "Expecting 200");
-                    resolve_test();
-                });
-    });
+//     await asyncTest("switchToChildProfile()", 2, function() {
+//         bc.identity.switchToChildProfile(null,
+//                 CHILD_APP_ID,
+//                 true,
+//                 function(result) {
+//                     ok(true, JSON.stringify(result));
+//                     equal(result.status, 200, "Expecting 200");
+//                     resolve_test();
+//                 });
+//     });
 
-    await asyncTest("switchToParentProfile()", 2, function() {
-        bc.identity.switchToParentProfile(PARENT_LEVEL_NAME,
-                function(result) {
-                    ok(true, JSON.stringify(result));
-                    equal(result.status, 200, "Expecting 200");
-                    resolve_test();
-                });
-    });
+//     await asyncTest("switchToParentProfile()", 2, function() {
+//         bc.identity.switchToParentProfile(PARENT_LEVEL_NAME,
+//                 function(result) {
+//                     ok(true, JSON.stringify(result));
+//                     equal(result.status, 200, "Expecting 200");
+//                     resolve_test();
+//                 });
+//     });
 
-    await asyncTest("getChildProfiles()", 2, function() {
-        bc.identity.getChildProfiles(true,
-                function(result) {
-                    ok(true, JSON.stringify(result));
-                    equal(result.status, 200, "Expecting 200");
-                    resolve_test();
-                });
-    });
+//     await asyncTest("getChildProfiles()", 2, function() {
+//         bc.identity.getChildProfiles(true,
+//                 function(result) {
+//                     ok(true, JSON.stringify(result));
+//                     equal(result.status, 200, "Expecting 200");
+//                     resolve_test();
+//                 });
+//     });
 
-    await asyncTest("switchToSingletonChildProfile()", 2, function() {
-        bc.identity.switchToSingletonChildProfile(
-                CHILD_APP_ID,
-                true,
-                function(result) {
-                    ok(true, JSON.stringify(result));
-                    equal(result.status, 200, "Expecting 200");
-                    resolve_test();
-                });
-    });
+//     await asyncTest("switchToSingletonChildProfile()", 2, function() {
+//         bc.identity.switchToSingletonChildProfile(
+//                 CHILD_APP_ID,
+//                 true,
+//                 function(result) {
+//                     ok(true, JSON.stringify(result));
+//                     equal(result.status, 200, "Expecting 200");
+//                     resolve_test();
+//                 });
+//     });
 
-    await asyncTest("runParentScript()", 2, function() {
-        bc.script.runParentScript(scriptName,
-                scriptData, PARENT_LEVEL_NAME, function(result) {
-                    ok(true, JSON.stringify(result));
-                    equal(result.status, 200, "Expecting 200");
-                    resolve_test();
-                });
-    });
+//     await asyncTest("runParentScript()", 2, function() {
+//         bc.script.runParentScript(scriptName,
+//                 scriptData, PARENT_LEVEL_NAME, function(result) {
+//                     ok(true, JSON.stringify(result));
+//                     equal(result.status, 200, "Expecting 200");
+//                     resolve_test();
+//                 });
+//     });
 
-    await asyncTest("detachParent()", 2, function() {
-        bc.identity.detachParent(function(result) {
-                    ok(true, JSON.stringify(result));
-                    equal(result.status, 200, "Expecting 200");
-                    resolve_test();
-                });
-    });
+//     await asyncTest("detachParent()", 2, function() {
+//         bc.identity.detachParent(function(result) {
+//                     ok(true, JSON.stringify(result));
+//                     equal(result.status, 200, "Expecting 200");
+//                     resolve_test();
+//                 });
+//     });
 
-    await asyncTest("attachParentWithIdentity()", 2, function() {
-        bc.identity.attachParentWithIdentity(
-            UserA.name, UserA.password,
-            bc.identity.authenticationType.universal,
-            null, true,
-            function(result) {
-                    ok(true, JSON.stringify(result));
-                    equal(result.status, 200, "Expecting 200");
-                    resolve_test();
-                });
-    });
+//     await asyncTest("attachParentWithIdentity()", 2, function() {
+//         bc.identity.attachParentWithIdentity(
+//             UserA.name, UserA.password,
+//             bc.identity.authenticationType.universal,
+//             null, true,
+//             function(result) {
+//                     ok(true, JSON.stringify(result));
+//                     equal(result.status, 200, "Expecting 200");
+//                     resolve_test();
+//                 });
+//     });
 
-    await asyncTest("switchToParentProfile()", 2, function() {
-        bc.identity.switchToParentProfile(PARENT_LEVEL_NAME,
-                function(result) {
-                    ok(true, JSON.stringify(result));
-                    equal(result.status, 200, "Expecting 200");
-                    resolve_test();
-                });
-    });
+//     await asyncTest("switchToParentProfile()", 2, function() {
+//         bc.identity.switchToParentProfile(PARENT_LEVEL_NAME,
+//                 function(result) {
+//                     ok(true, JSON.stringify(result));
+//                     equal(result.status, 200, "Expecting 200");
+//                     resolve_test();
+//                 });
+//     });
 
-    await asyncTest("attachPeerProfile()", 2, function() {
-        bc.identity.attachPeerProfile(
-            PEER_NAME,UserA.name, UserA.password,
-            bc.identity.authenticationType.universal,
-                null, true,
-            function(result) {
-                    ok(true, JSON.stringify(result));
-                    equal(result.status, 200, "Expecting 200");
-                    resolve_test();
-                });
-    });
+//     await asyncTest("attachPeerProfile()", 2, function() {
+//         bc.identity.attachPeerProfile(
+//             PEER_NAME,UserA.name, UserA.password,
+//             bc.identity.authenticationType.universal,
+//                 null, true,
+//             function(result) {
+//                     ok(true, JSON.stringify(result));
+//                     equal(result.status, 200, "Expecting 200");
+//                     resolve_test();
+//                 });
+//     });
 
-    await asyncTest("detachPeer()", 2, function() {
-        bc.identity.detachPeer(
-            PEER_NAME,
-            function(result) {
-                    ok(true, JSON.stringify(result));
-                    equal(result.status, 200, "Expecting 200");
-                    resolve_test();
-                });
-    });
+//     await asyncTest("detachPeer()", 2, function() {
+//         bc.identity.detachPeer(
+//             PEER_NAME,
+//             function(result) {
+//                     ok(true, JSON.stringify(result));
+//                     equal(result.status, 200, "Expecting 200");
+//                     resolve_test();
+//                 });
+//     });
 
-    await asyncTest("getPeerProfiles()", 2, function() {
-        bc.identity.getPeerProfiles(
-            function(result) {
-                    ok(true, JSON.stringify(result));
-                    equal(result.status, 200, "Expecting 200");
-                    resolve_test();
-                });
-    });
+//     await asyncTest("getPeerProfiles()", 2, function() {
+//         bc.identity.getPeerProfiles(
+//             function(result) {
+//                     ok(true, JSON.stringify(result));
+//                     equal(result.status, 200, "Expecting 200");
+//                     resolve_test();
+//                 });
+//     });
 
-    await asyncTest("logout()", function() {
-        bc.playerState.logout(function(result) {
-            equal(result.status, 200, JSON.stringify(result));
-            resolve_test();
-        });
-    });
+//     await asyncTest("logout()", function() {
+//         bc.playerState.logout(function(result) {
+//             equal(result.status, 200, JSON.stringify(result));
+//             resolve_test();
+//         });
+//     });
 
-    await asyncTest("attachNonLoginUniversalId()", function() {
-        bc.identity.attachNonLoginUniversalId("braincloudtest@test.getbraincloud.com", function(result) {
-            equal(result.status, 403, JSON.stringify(result));
-            resolve_test();
-        });
-    });
+//     await asyncTest("attachNonLoginUniversalId()", function() {
+//         bc.identity.attachNonLoginUniversalId("braincloudtest@test.getbraincloud.com", function(result) {
+//             equal(result.status, 403, JSON.stringify(result));
+//             resolve_test();
+//         });
+//     });
 
-    await asyncTest("updateUniversalLoginId()", function() {
-        bc.identity.updateUniversalIdLogin("braincloudtest@test.getbraincloud.com", function(result) {
-            equal(result.status, 403, JSON.stringify(result));
-            resolve_test();
-        });
-    });
-}
+//     await asyncTest("updateUniversalLoginId()", function() {
+//         bc.identity.updateUniversalIdLogin("braincloudtest@test.getbraincloud.com", function(result) {
+//             equal(result.status, 403, JSON.stringify(result));
+//             resolve_test();
+//         });
+//     });
+// }
 
 ////////////////////////////////////////
 // Comms tests
@@ -8198,7 +8196,7 @@ async function run_tests()
     await testGlobalEntity();
     await testGroupFile();
     await testGroup();
-    await testIdentity();
+    //await testIdentity();     // TODO
     await testNewIdentity();    // TODO
     await testMail();
     await testMatchMaking();
@@ -8218,7 +8216,7 @@ async function run_tests()
     await testSocialLeaderboard();
     await testTime();
     await testTournament();
-    await testSharedIdentity();
+    //await testSharedIdentity(); // TODO
     await testFile();
     await testChat();
     await testMessaging();

--- a/test/test.js
+++ b/test/test.js
@@ -3218,342 +3218,279 @@ async function testGroup() {
     })
 }
 
-// TODO:  Create new Identity Service test
+////////////////////////////////////////
+// Identity tests
+////////////////////////////////////////
 async function testIdentity() {
-    bc.brainCloudClient.setDebugEnabled(true);
+    bc.brainCloudClient.setDebugEnabled(true)
 
-    bc.initialize(GAME_ID, SECRET, GAME_VERSION);
+    bc.initialize(GAME_ID, SECRET, GAME_VERSION)
 
-    bc.brainCloudClient.setServerUrl(SERVER_URL);
+    bc.brainCloudClient.setServerUrl(SERVER_URL)
 
-    var today = new Date();
-    var time = today.getTime();
-    var universalId = "identityTestUserUniversalId" + time;
-    var email = "identityTestUserEmail" + time + "@email.com";
-    var password = "password";
-    var blockChainPublicKey = "publicKey" + time;
-    var nonLoginUniversalId = "identityTestUserNonLoginUniversalId" + time;
-    var parentUniversalId = "identityTestUserParentUniversalId" + time;
-    var peerExternalId = "identityTestUserPeerExternalId" + time + "@email.com";
-    //var peer = "peerapp" + time;
+    var today = new Date()
+    var time = today.getTime()
+    var universalId = "identityTestUserUniversalId" + time
+    var email = "identityTestUserEmail" + time + "@email.com"
+    var password = "password"
+    var blockChainPublicKey = "publicKey" + time
+    var nonLoginUniversalId = "identityTestUserNonLoginUniversalId" + time
+    var parentUniversalId = "identityTestUserParentUniversalId" + time
 
-    if (!module("NewIdentity", null, null)) return;
+    if (!module("NewIdentity", null, null)) return
 
-    // TODO:  All Identity Service APIs per API DOCS
-
-    // AttachAdvancedIdentity
-    await asyncTest("testAttachDetacAdvancedIdentity()", 4, function () {
+    await asyncTest("testAttachDetachAdvancedIdentity()", 2, function () {
 
         bc.resetStoredProfileId();
 
-        var authenticationType = bc.brainCloudClient.authentication.AUTHENTICATION_TYPE_UNIVERSAL;
-        var ids = { externalId: universalId + "Advanced", authenticationToken: password, authenticationSubType: "" };
-        var extraJson = { "key": "value" };
+        var authenticationType = bc.brainCloudClient.authentication.AUTHENTICATION_TYPE_UNIVERSAL
+        var ids = { externalId: universalId + "Advanced", authenticationToken: password, authenticationSubType: "" }
+        var extraJson = { "key": "value" }
 
         bc.authenticateAnonymous(function (authResponse) {
             if (authResponse.status === 200) {
-                console.log("success")
                 bc.identity.attachAdvancedIdentity(authenticationType, ids, extraJson, (attachResponse) => {
-                    ok(true, JSON.stringify(attachResponse));
-                    equal(attachResponse.status, 200, "Expecting 200");
+                    equal(attachResponse.status, 200, "Expecting 200")
 
                     bc.identity.detachAdvancedIdentity(authenticationType, universalId + "Advanced", true, extraJson, (detachResponse) => {
-                        ok(true, JSON.stringify(detachResponse));
-                        equal(detachResponse.status, 200, "Expecting 200");
-                        resolve_test();
-                    });
-                });
+                        equal(detachResponse.status, 200, "Expecting 200")
+                        
+                        bc.playerState.logout(() => {
+                            resolve_test()
+                        })
+                    })
+                })
             }
             else {
-                console.log("fail")
                 resolve_test()
             }
-        });
-    });
+        })
+    })
 
-    // TODO:  AttachAppleIdentity
+    await asyncTest("testAttachDetachBlockchainIdentity()", 2, function () {
 
-    // AttachBlockchainIdentity
-    await asyncTest("testAttachDetachBlockchainIdentity()", 5, function () {
-
-        bc.resetStoredProfileId();
+        bc.resetStoredProfileId()
 
         bc.authenticateUniversal("identityBlockchainTestUser", password, true, function (authResponse) {
             if (authResponse.status === 200) {
                 bc.identity.attachBlockchainIdentity("config", blockChainPublicKey, (attachResponse) => {
-                    ok(true, JSON.stringify(attachResponse));
-                    equal(attachResponse.status, 200, "Expecting 200");
+                    equal(attachResponse.status, 200, "Expecting 200")
 
                     bc.identity.detachBlockchainIdentity("config", (detachResponse) => {
-                        ok(true, JSON.stringify(detachResponse));
-                        equal(detachResponse.status, 200, "Expecting 200");
+                        equal(detachResponse.status, 200, "Expecting 200")
 
-                        bc.playerState.logout((logoutResponse) => {
-                            equal(logoutResponse.status, 200, "Expecting 200");
-                            resolve_test();
-                        });
-                    });
-                });
+                        bc.playerState.logout(() => {
+                            resolve_test()
+                        })
+                    })
+                })
             }
             else {
-                console.log("fail")
                 resolve_test()
             }
-        });
-    });
+        })
+    })
 
     // AttachEmailIdentity
-    await asyncTest("testAttachDetachEmailIdentity()", 5, function () {
+    await asyncTest("testAttachDetachEmailIdentity()", 2, function () {
 
-        bc.resetStoredProfileId();
+        bc.resetStoredProfileId()
 
         bc.authenticateAnonymous(function (authResponse) {
             if (authResponse.status === 200) {
-                console.log("success")
                 bc.identity.attachEmailIdentity(email, password, (attachResponse) => {
-                    ok(true, JSON.stringify(attachResponse));
-                    equal(attachResponse.status, 200, "Expecting 200");
+                    equal(attachResponse.status, 200, "Expecting 200")
 
                     bc.identity.detachEmailIdentity(email, true, (detachResponse) => {
-                        ok(true, JSON.stringify(detachResponse));
-                        equal(detachResponse.status, 200, "Expecting 200");
+                        equal(detachResponse.status, 200, "Expecting 200")
                         
-                        bc.playerState.logout((logoutResponse) => {
-                            equal(logoutResponse.status, 200, "Expecting 200");
-                            resolve_test();
-                        });
-                    });
-                });
+                        bc.playerState.logout(() => {
+                            resolve_test()
+                        })
+                    })
+                })
             }
             else {
-                console.log("fail")
                 resolve_test()
             }
-        });
-    });
-    // TODO:  AttachFacebookIdentity
-    // TODO:  AttachFacebookLimitedIdentity
-    // TODO:  AttachGameCenterIdentity
-    // TODO:  AttachGoogleIdentity
-    // TODO:  AttachGoogleOpenIdIdentity
+        })
+    })
 
-    // AttachNonLoginUniversalId
-    await asyncTest("testAttachNonLoginUniversalId()", 3, function () {
+    await asyncTest("testAttachNonLoginUniversalId()", 1, function () {
 
-        bc.resetStoredProfileId();
+        bc.resetStoredProfileId()
 
         bc.authenticateEmailPassword(email, password, true, function (authResponse) {
             if (authResponse.status === 200) {
-                console.log("success")
                 bc.identity.attachNonLoginUniversalId(nonLoginUniversalId, (attachResponse) => {
-                    ok(true, JSON.stringify(attachResponse));
-                    equal(attachResponse.status, 200, "Expecting 200");
-                    
-                    bc.playerState.logout((logoutResponse) => {
-                        equal(logoutResponse.status, 200, "Expecting 200");
-                        resolve_test();
-                    });
-                });
+                    equal(attachResponse.status, 200, "Expecting 200")
+
+                    bc.playerState.logout(() => {
+                        resolve_test()
+                    })
+                })
             }
             else {
-                console.log("fail")
                 resolve_test()
             }
-        });
-    });
+        })
+    })
 
-    // TODO:  AttachParentWithIdentity
     await asyncTest("testAttachDetachParentWithIdentity()", 3, function () {
 
-        //bc.resetStoredProfileId();
         initializeClient()
 
-        var externalId = parentUniversalId;
-        var authenticationToken = password;
+        var externalId = parentUniversalId
+        var authenticationToken = password
         var authenticationType = bc.identity.authenticationType.universal
-        var externalAuthName = null;
-        var forceCreate = true;
+        var externalAuthName = null
+        var forceCreate = true
 
         bc.authenticateAnonymous(function (authResponse) {
             if (authResponse.status === 200) {
 
                 // Switch to Child
                 bc.identity.switchToChildProfile(null, CHILD_APP_ID, true, (switchToChildResponse) => {
-                    equal(switchToChildResponse.status, 200, "Expecting 200");
+                    equal(switchToChildResponse.status, 200, "Expecting 200")
 
                     bc.identity.detachParent(detachResponse => {
                         equal(detachResponse.status, 200, " expecting successful detach")
 
                         // Attach
                         bc.identity.attachParentWithIdentity(externalId, authenticationToken, authenticationType, externalAuthName, forceCreate, (attachResponse) => {
-                            equal(attachResponse.status, 200, "Expecting 200");
+                            equal(attachResponse.status, 200, "Expecting 200")
 
                             bc.playerState.logout(() => {
-                                resolve_test();
-                            });
-                        });
+                                resolve_test()
+                            })
+                        })
                     })
                 })
             }
             else {
-                console.log("fail")
                 resolve_test()
             }
-        });
-    });
+        })
+    })
 
-    // TODO:  AttachParseIdentity
-
-    // AttachPeerProfile
-    await asyncTest("testAttachDetachPeerProfile()", 3, function () {
+    await asyncTest("testAttachDetachPeerProfile()", 2, function () {
 
         initializeClient()
 
         bc.authenticateUniversal(UserA.name, UserA.password, true, function (authResponse) {
             if (authResponse.status === 200) {
-                var authenticationType = bc.identity.authenticationType.universal;
-                var externalAuthName = "";
+                var authenticationType = bc.identity.authenticationType.universal
+                var externalAuthName = ""
 
                 bc.identity.attachPeerProfile(PEER_NAME, UserA.name + "_peer", password, authenticationType, externalAuthName, true, (attachResponse) => {
-                    equal(attachResponse.status, 200, "Expecting Successful Attach");
+                    equal(attachResponse.status, 200, "Expecting Successful Attach")
 
                     bc.identity.detachPeer(PEER_NAME, (detachResponse) => {
-                        equal(detachResponse.status, 200, "Expecting Successful Detach");
+                        equal(detachResponse.status, 200, "Expecting Successful Detach")
 
-                        bc.playerState.logout((logoutResponse) => {
-                            equal(logoutResponse.status, 200, "Expecting Successful Logout");
-                            resolve_test();
-                        });
-                    });
-                });
+                        bc.playerState.logout(() => {
+                            resolve_test()
+                        })
+                    })
+                })
             }
             else {
-                console.log("Initial authentication failed. Test cannot proceed.");
-                resolve_test();
+                resolve_test()
             }
-        });
-    });
+        })
+    })
 
-    // TODO:  AttachSteamIdentity
-    // TODO:  AttachTwitterIdentity
-    // TODO:  AttachUltraIdentity
+    await asyncTest("testAttachDetachUniversalIdentity()", 2, function () {
 
-    // AttachUniversalIdentity
-    await asyncTest("testAttachDetachUniversalIdentity()", 5, function () {
-
-        bc.resetStoredProfileId();
+        bc.resetStoredProfileId()
 
         bc.authenticateAnonymous(function (authResponse) {
             if (authResponse.status === 200) {
-                console.log("success")
                 bc.identity.attachUniversalIdentity(universalId, password, (attachResponse) => {
-                    ok(true, JSON.stringify(attachResponse));
-                    equal(attachResponse.status, 200, "Expecting 200");
+                    equal(attachResponse.status, 200, "Expecting 200")
 
                     bc.identity.detachUniversalIdentity(universalId, true, (detachResponse) => {
-                        ok(true, JSON.stringify(detachResponse));
-                        equal(detachResponse.status, 200, "Expecting 200");
+                        equal(detachResponse.status, 200, "Expecting 200")
                         
-                        bc.playerState.logout((logoutResponse) => {
-                            equal(logoutResponse.status, 200, "Expecting 200");
-                            resolve_test();
-                        });
-                    });
-                });
+                        bc.playerState.logout(() => {
+                            resolve_test()
+                        })
+                    })
+                })
             }
             else {
-                console.log("fail")
                 resolve_test()
             }
-        });
-    });
+        })
+    })
 
-    // ChangeEmailIdentity
-    await asyncTest("testChangeEmailIdentity()", 2, function () {
+    await asyncTest("testChangeEmailIdentity()", 1, function () {
         bc.authenticateEmailPassword(email, password, true, (authResponse) => {
             if (authResponse.status === 200) {
                 bc.identity.changeEmailIdentity(email, password, "new" + email, true, (changeEmailResponse) => {
-                    equal(changeEmailResponse.status, 200, "Expecting 200");
+                    equal(changeEmailResponse.status, 200, "Expecting 200")
 
-                    bc.playerState.logout((logoutResponse) => {
-                        equal(logoutResponse.status, 200, "Expecting 200");
-                        resolve_test();
-                    });
-                });
+                    bc.playerState.logout(() => {
+                        resolve_test()
+                    })
+                })
             }
             else {
-                resolve_test();
+                resolve_test()
             }
-        });
-    });
+        })
+    })
 
-    // TODO:  DetachAppleIdentity
-    // TODO:  DetachFacebookIdentity
-    // TODO:  DetachFacebookLimitedIdentity
-    // TODO:  DetachGameCenterIdentity
-    // TODO:  DetachGoogleIdentity
-    // TODO:  DetachGoogleOpenIdIdentity
-    // TODO:  DetachParseIdentity
-    // TODO:  DetachSteamIdentity
-    // TODO:  DetachTwitterIdentity
-    // TODO:  DetachUltraIdentity
-
-    // GetChildProfiles
-    await asyncTest("testGetChildProfiles()", 2, function () {
+    await asyncTest("testGetChildProfiles()", 1, function () {
         bc.authenticateAnonymous((authResponse) => {
             if (authResponse.status === 200) {
                 bc.identity.getChildProfiles(true, (response) => {
-                    equal(response.status, 200, "Expecting 200");
+                    equal(response.status, 200, "Expecting 200")
 
-                    bc.playerState.logout((logoutResponse) => {
-                        equal(logoutResponse.status, 200, "Expecting 200");
-                        resolve_test();
-                    });
-                });
+                    bc.playerState.logout(() => {
+                        resolve_test()
+                    })
+                })
             }
             else {
-                resolve_test();
+                resolve_test()
             }
-        });
-    });
+        })
+    })
 
-    // GetExpiredIdentities
-    await asyncTest("testGetExpiredIdentities()", 2, function () {
+    await asyncTest("testGetExpiredIdentities()", 1, function () {
         bc.authenticateAnonymous((authResponse) => {
             if (authResponse.status === 200) {
                 bc.identity.getExpiredIdentities((response) => {
-                    equal(response.status, 200, "Expecting 200");
+                    equal(response.status, 200, "Expecting 200")
 
-                    bc.playerState.logout((logoutResponse) => {
-                        equal(logoutResponse.status, 200, "Expecting 200");
-                        resolve_test();
-                    });
-                });
+                    bc.playerState.logout(() => {
+                        resolve_test()
+                    })
+                })
             }
             else {
-                resolve_test();
+                resolve_test()
             }
-        });
-    });
+        })
+    })
 
-    // GetIdentities
-    await asyncTest("testGetIdentities()", 2, function () {
+    await asyncTest("testGetIdentities()", 1, function () {
         bc.authenticateAnonymous((authResponse) => {
             if (authResponse.status === 200) {
                 bc.identity.getIdentities((response) => {
-                    equal(response.status, 200, "Expecting 200");
+                    equal(response.status, 200, "Expecting 200")
 
-                    bc.playerState.logout((logoutResponse) => {
-                        equal(logoutResponse.status, 200, "Expecting 200");
-                        resolve_test();
-                    });
-                });
+                    bc.playerState.logout(() => {
+                        resolve_test()
+                    })
+                })
             }
             else {
-                resolve_test();
+                resolve_test()
             }
-        });
-    });
+        })
+    })
 
     // TODO:  GetIdentityStatus
     // TODO: getIdentityStatus is not a function
@@ -3581,121 +3518,74 @@ async function testIdentity() {
     //     });
     // });
 
-    // TODO:  GetPeerProfiles
-    await asyncTest("testGetPeerProfiles()", 2, function () {
+    await asyncTest("testGetPeerProfiles()", 1, function () {
         
         bc.authenticateAnonymous((authResponse) => {
             if(authResponse.status === 200){
                 bc.identity.getPeerProfiles((response) => {
-                    equal(response.status, 200, " Expecting Successful Response");
+                    equal(response.status, 200, " Expecting Successful Response")
 
-                    bc.playerState.logout((logoutResponse) => {
-                        equal(logoutResponse.status, 200, " Expecting Successful Logout");
-                        resolve_test();
-                    });
-                });
+                    bc.playerState.logout(() => {
+                        resolve_test()
+                    })
+                })
             }
             else{
-                console.log("Initial authentication failed. Test cannot proceed.");
-                resolve_test();
+                resolve_test()
             }
-        });
-    });
+        })
+    })
 
-    // TODO:  MergeAdvancedIdentity
-    // TODO:  MergeAppleIdentity
-
-    // MergeEmailIdentity
     await asyncTest("testMergeEmailIdentity()", 1, function () {
-        var mergeEmail = "merge" + email;
-
+        var mergeEmail = "merge" + email
 
         bc.authenticateEmailPassword(mergeEmail, password, true, () => {
             bc.playerState.logout(() => {
                 bc.authenticateUniversal(universalId, password, true, (authResponse) => {
                     if (authResponse.status === 200) {
                         bc.identity.mergeEmailIdentity(mergeEmail, password, (mergeResponse) => {
-                            equal(mergeResponse.status, 200, " Expecting Successful Merge");
+                            equal(mergeResponse.status, 200, " Expecting Successful Merge")
 
                             bc.playerState.logout(() => {
-                                resolve_test();
+                                resolve_test()
                             })
-                        });
+                        })
                     }
                     else {
-                        console.log("Authentication failed. Test cannot proceed.");
-                        resolve_test();
+                        resolve_test()
                     }
-                });
-            });
-        });
-    });
+                })
+            })
+        })
+    })
 
-    // TODO:  MergeFacebookIdentity
-    // TODO:  MergeFacebookLimitedIdentity
-    // TODO:  MergeGameCenterIdentity
-    // TODO:  MergeGoogleIdentity
-    // TODO:  MergeGoogleOpenIdIdentity
-    // TODO:  MergeParseIdentity
-    // TODO:  MergeSteamIdentity
-    // TODO:  MergeTwitterIdentity
-    // TODO:  MergeUltraIdentity
-
-    // MergeUniversalIdentity
     await asyncTest("testMergeUniversalIdentity()", 1, function () {
-        var mergeUniversalId = "merge" + universalId;
+        var mergeUniversalId = "merge" + universalId
         
         bc.authenticateUniversal(mergeUniversalId, password, true, () => {
             bc.playerState.logout(() => {
                 bc.authenticateEmailPassword(email, password, true, (authResponse) => {
                     if (authResponse.status === 200) {
                         bc.identity.mergeUniversalIdentity(mergeUniversalId, password, (mergeResponse) => {
-                            equal(mergeResponse.status, 200, " Expecting Successful Merge");
+                            equal(mergeResponse.status, 200, " Expecting Successful Merge")
 
                             bc.playerState.logout(() => {
-                                resolve_test();
+                                resolve_test()
                             })
-                        });
+                        })
                     }
                     else {
-                        console.log("Authentication failed. Test cannot proceed.");
-                        resolve_test();
+                        resolve_test()
                     }
-                });
-            });
-        });
-    });
+                })
+            })
+        })
+    })
 
-    // TODO:  RefreshIdentity
-    // TODO:  intended for things like facebook:
-    //          we get a token that is used for requests but this token can expire so we would need to refresh
-    // await asyncTest("testRefreshIdentity()", 1, function () {
-    //     bc.resetStoredProfileId();
-
-    //     bc.authenticateAnonymous((authResponse) => {
-    //         if(authResponse.status === 200){
-    //             var authenticationType = bc.identity.authenticationType.universal
-                
-    //             bc.identity.refreshIdentity(universalId, password, authenticationType, (response) => {
-    //                 equal(response.status, 200, " Expecting Successful Response");
-
-    //                 bc.playerState.logout(() => {
-    //                     resolve_test();
-    //                 });
-    //             });
-    //         }
-    //         else{
-    //             console.log("Initial authentication failed. Test cannot proceed.");
-    //             resolve_test();
-    //         }
-    //     });
-    // });
-
-    // SwitchToParentProfile
     await asyncTest("testSwitchToSingletonChildAndParentProfile()", 2, () => {
-        bc.resetStoredProfileId();
+        bc.resetStoredProfileId()
 
-        initializeClient();
+        initializeClient()
 
         bc.authenticateUniversal(UserA.name, UserA.password, true, authResponse => {
             if(authResponse.status === 200){
@@ -3712,13 +3602,11 @@ async function testIdentity() {
                 })
             }
             else{
-                console.log("Authentication failed. Test cannot proceed.")
                 resolve_test()
             }
         })
     })
 
-    // UpdateUniversalIdLogin
     await asyncTest("testUpdateUniversalIdLogin()", 1, () => {
         bc.authenticateUniversal(universalId, password, true, authResponse => {
             if(authResponse.status === 200){
@@ -3731,7 +3619,6 @@ async function testIdentity() {
                 })
             }
             else{
-                console.log("Authentication failed. Test cannot proceed.")
                 resolve_test()
             }
         })

--- a/test/test.js
+++ b/test/test.js
@@ -3492,31 +3492,27 @@ async function testIdentity() {
         })
     })
 
-    // TODO:  GetIdentityStatus
-    // TODO: getIdentityStatus is not a function
-    // await asyncTest("testGetIdentityStatus()", 2, function () {
+    await asyncTest("testGetIdentityStatus()", 1, function () {
 
-    //     bc.authenticateAnonymous((authResponse) => {
-    //         if (authResponse.status === 200) {
-    //             //
-    //             var authenticationType = bc.identity.authenticationType.email;
-    //             var externalAuthName = "";
+        bc.authenticateUniversal(universalId, password, true, (authResponse) => {
+            if (authResponse.status === 200) {
+                
+                var authenticationType = bc.identity.authenticationType.universal;
+                var externalAuthName = "";
 
-    //             bc.identity.getIdentityStatus(authenticationType, externalAuthName, (response) => {
-    //                 equal(response.status, 200, " Expecting Successful Response");
+                bc.identity.getIdentityStatus(authenticationType, externalAuthName, (response) => {
+                    equal(response.status, 200, " Expecting Successful Response")
 
-    //                 bc.playerState.logout((logoutResponse) => {
-    //                     equal(logoutResponse.status, 200, " Expecting Successful Logout");
-    //                     resolve_test();
-    //                 });
-    //             });
-    //         }
-    //         else {
-    //             console.log("Initial authentication failed. Test cannot proceed.");
-    //             resolve_test();
-    //         }
-    //     });
-    // });
+                    bc.playerState.logout(() => {
+                        resolve_test()
+                    })
+                })
+            }
+            else {
+                resolve_test()
+            }
+        })
+    })
 
     await asyncTest("testGetPeerProfiles()", 1, function () {
         

--- a/test/test.js
+++ b/test/test.js
@@ -3218,6 +3218,535 @@ async function testGroup() {
     })
 }
 
+// TODO:  Create new Identity Service test
+async function testNewIdentity() {
+    bc.brainCloudClient.setDebugEnabled(true);
+
+    bc.initialize(GAME_ID, SECRET, GAME_VERSION);
+
+    bc.brainCloudClient.setServerUrl(SERVER_URL);
+
+    var today = new Date();
+    var time = today.getTime();
+    var universalId = "identityTestUserUniversalId" + time;
+    var email = "identityTestUserEmail" + time + "@email.com";
+    var password = "password";
+    var blockChainPublicKey = "publicKey" + time;
+    var nonLoginUniversalId = "identityTestUserNonLoginUniversalId" + time;
+    var parentUniversalId = "identityTestUserParentUniversalId" + time;
+    var peerExternalId = "identityTestUserPeerExternalId" + time + "@email.com";
+    //var peer = "peerapp" + time;
+
+    if (!module("NewIdentity", null, null)) return;
+
+    // TODO:  All Identity Service APIs per API DOCS
+
+    // TODO:  AttachAdvancedIdentity
+    // TODO:  bug in attachAdvancedIdentity - undefined "externalAuthName"
+    //        should be checking if ids.authenticationSubType instead of if externalAuthName
+    // await asyncTest("testAttachDetacAdvancedIdentity()", 4, function () {
+
+    //     bc.resetStoredProfileId();
+
+    //     var authenticationType = bc.brainCloudClient.authentication.AUTHENTICATION_TYPE_UNIVERSAL;
+    //     var ids = { externalId: universalId, authenticationToken: password, authenticationSubType: "" };
+    //     var forceCreate = true;
+    //     var extraJson = { "key": "value" };
+
+    //     bc.authenticateAnonymous(function (authResponse) {
+    //         if (authResponse.status === 200) {
+    //             console.log("success")
+    //             bc.identity.attachAdvancedIdentity(authenticationType, ids, forceCreate, extraJson, (attachResponse) => {
+    //                 ok(true, JSON.stringify(attachResponse));
+    //                 equal(attachResponse.status, 200, "Expecting 200");
+
+    //                 bc.identity.detachAdvancedIdentity(authenticationType, ids, forceCreate, extraJson, (detachResponse) => {
+    //                     ok(true, JSON.stringify(detachResponse));
+    //                     equal(detachResponse.status, 200, "Expecting 200");
+    //                     resolve_test();
+    //                 });
+    //             });
+    //         }
+    //         else {
+    //             console.log("fail")
+    //             resolve_test()
+    //         }
+    //     });
+    // });
+
+    // TODO:  AttachAppleIdentity
+
+
+    // AttachBlockchainIdentity
+    await asyncTest("testAttachDetachBlockchainIdentity()", 5, function () {
+
+        bc.resetStoredProfileId();
+
+        bc.authenticateUniversal("identityBlockchainTestUser", password, true, function (authResponse) {
+            if (authResponse.status === 200) {
+                bc.identity.attachBlockchainIdentity("config", blockChainPublicKey, (attachResponse) => {
+                    ok(true, JSON.stringify(attachResponse));
+                    equal(attachResponse.status, 200, "Expecting 200");
+
+                    bc.identity.detachBlockchainIdentity("config", (detachResponse) => {
+                        ok(true, JSON.stringify(detachResponse));
+                        equal(detachResponse.status, 200, "Expecting 200");
+
+                        bc.playerState.logout((logoutResponse) => {
+                            equal(logoutResponse.status, 200, "Expecting 200");
+                            resolve_test();
+                        });
+                    });
+                });
+            }
+            else {
+                console.log("fail")
+                resolve_test()
+            }
+        });
+    });
+
+    // AttachEmailIdentity
+    await asyncTest("testAttachDetachEmailIdentity()", 5, function () {
+
+        bc.resetStoredProfileId();
+
+        bc.authenticateAnonymous(function (authResponse) {
+            if (authResponse.status === 200) {
+                console.log("success")
+                bc.identity.attachEmailIdentity(email, password, (attachResponse) => {
+                    ok(true, JSON.stringify(attachResponse));
+                    equal(attachResponse.status, 200, "Expecting 200");
+
+                    bc.identity.detachEmailIdentity(email, true, (detachResponse) => {
+                        ok(true, JSON.stringify(detachResponse));
+                        equal(detachResponse.status, 200, "Expecting 200");
+                        
+                        bc.playerState.logout((logoutResponse) => {
+                            equal(logoutResponse.status, 200, "Expecting 200");
+                            resolve_test();
+                        });
+                    });
+                });
+            }
+            else {
+                console.log("fail")
+                resolve_test()
+            }
+        });
+    });
+    // TODO:  AttachFacebookIdentity
+    // TODO:  AttachFacebookLimitedIdentity
+    // TODO:  AttachGameCenterIdentity
+    // TODO:  AttachGoogleIdentity
+    // TODO:  AttachGoogleOpenIdIdentity
+
+    // AttachNonLoginUniversalId
+    await asyncTest("testAttachNonLoginUniversalId()", 3, function () {
+
+        bc.resetStoredProfileId();
+
+        bc.authenticateEmailPassword(email, password, true, function (authResponse) {
+            if (authResponse.status === 200) {
+                console.log("success")
+                bc.identity.attachNonLoginUniversalId(nonLoginUniversalId, (attachResponse) => {
+                    ok(true, JSON.stringify(attachResponse));
+                    equal(attachResponse.status, 200, "Expecting 200");
+                    
+                    bc.playerState.logout((logoutResponse) => {
+                        equal(logoutResponse.status, 200, "Expecting 200");
+                        resolve_test();
+                    });
+                });
+            }
+            else {
+                console.log("fail")
+                resolve_test()
+            }
+        });
+    });
+
+    // TODO:  AttachParentWithIdentity
+    // TODO:  40301 error on attach: The brainCloud library was initialized with an incorrect secret.
+    // await asyncTest("testAttachDetachParentWithIdentity()", 7, function () {
+
+    //     //bc.resetStoredProfileId();
+
+    //     var externalId = parentUniversalId;
+    //     var authenticationToken = password;
+    //     var authenticationType = bc.identity.authenticationType.universal
+    //     var externalAuthName = null;
+    //     var forceCreate = true;
+
+    //     bc.authenticateAnonymous(function (authResponse) {
+    //         if (authResponse.status === 200) {
+
+    //             // Switch to Child
+    //             bc.identity.switchToChildProfile(null, CHILD_APP_ID, true, (switchToChildResponse) => {
+    //                 ok(true, JSON.stringify(switchToChildResponse));
+    //                 equal(switchToChildResponse.status, 200, "Expecting 200");
+
+    //                 // Attach
+    //                 bc.identity.attachParentWithIdentity(externalId, authenticationToken, authenticationType, externalAuthName, forceCreate, (attachResponse) => {
+    //                     ok(true, JSON.stringify(attachResponse));
+    //                     equal(attachResponse.status, 200, "Expecting 200");
+
+    //                     // Detach
+    //                     bc.identity.detachParent((detachResponse) => {
+    //                         ok(true, JSON.stringify(detachResponse));
+    //                         equal(detachResponse.status, 200, "Expecting 200");
+
+    //                         bc.playerState.logout((logoutResponse) => {
+    //                             equal(logoutResponse.status, 200, "Expecting 200");
+    //                             resolve_test();
+    //                         });
+    //                     });
+    //                 });
+    //             });
+    //         }
+    //         else {
+    //             console.log("fail")
+    //             resolve_test()
+    //         }
+    //     });
+    // });
+
+    // TODO:  AttachParseIdentity
+
+    // AttachPeerProfile
+    await asyncTest("testAttachDetachPeerProfile()", 3, function () {
+
+        bc.resetStoredProfileId();
+
+        bc.authenticateAnonymous(function (authResponse) {
+            if (authResponse.status === 200) {
+                var authenticationType = bc.identity.authenticationType.email;
+                var externalAuthName = "";
+
+                bc.identity.attachPeerProfile(PEER_NAME, peerExternalId, password, authenticationType, externalAuthName, true, (attachResponse) => {
+                    equal(attachResponse.status, 200, "Expecting Successful Attach");
+
+                    bc.identity.detachPeer(PEER_NAME, (detachResponse) => {
+                        equal(detachResponse.status, 200, "Expecting Successful Detach");
+
+                        bc.playerState.logout((logoutResponse) => {
+                            equal(logoutResponse.status, 200, "Expecting Successful Logout");
+                            resolve_test();
+                        });
+                    });
+                });
+            }
+            else {
+                console.log("Initial authentication failed. Test cannot proceed.");
+                resolve_test();
+            }
+        });
+    });
+
+    // TODO:  AttachSteamIdentity
+    // TODO:  AttachTwitterIdentity
+    // TODO:  AttachUltraIdentity
+
+    // AttachUniversalIdentity
+    await asyncTest("testAttachDetachUniversalIdentity()", 5, function () {
+
+        bc.resetStoredProfileId();
+
+        bc.authenticateAnonymous(function (authResponse) {
+            if (authResponse.status === 200) {
+                console.log("success")
+                bc.identity.attachUniversalIdentity(universalId, password, (attachResponse) => {
+                    ok(true, JSON.stringify(attachResponse));
+                    equal(attachResponse.status, 200, "Expecting 200");
+
+                    bc.identity.detachUniversalIdentity(universalId, true, (detachResponse) => {
+                        ok(true, JSON.stringify(detachResponse));
+                        equal(detachResponse.status, 200, "Expecting 200");
+                        
+                        bc.playerState.logout((logoutResponse) => {
+                            equal(logoutResponse.status, 200, "Expecting 200");
+                            resolve_test();
+                        });
+                    });
+                });
+            }
+            else {
+                console.log("fail")
+                resolve_test()
+            }
+        });
+    });
+
+    // ChangeEmailIdentity
+    await asyncTest("testChangeEmailIdentity()", 2, function () {
+        bc.authenticateEmailPassword(email, password, true, (authResponse) => {
+            if (authResponse.status === 200) {
+                bc.identity.changeEmailIdentity(email, password, "new" + email, true, (changeEmailResponse) => {
+                    equal(changeEmailResponse.status, 200, "Expecting 200");
+
+                    bc.playerState.logout((logoutResponse) => {
+                        equal(logoutResponse.status, 200, "Expecting 200");
+                        resolve_test();
+                    });
+                });
+            }
+            else {
+                resolve_test();
+            }
+        });
+    });
+
+    // TODO:  DetachAppleIdentity
+    // TODO:  DetachFacebookIdentity
+    // TODO:  DetachFacebookLimitedIdentity
+    // TODO:  DetachGameCenterIdentity
+    // TODO:  DetachGoogleIdentity
+    // TODO:  DetachGoogleOpenIdIdentity
+    // TODO:  DetachParseIdentity
+    // TODO:  DetachSteamIdentity
+    // TODO:  DetachTwitterIdentity
+    // TODO:  DetachUltraIdentity
+
+    // GetChildProfiles
+    await asyncTest("testGetChildProfiles()", 2, function () {
+        bc.authenticateAnonymous((authResponse) => {
+            if (authResponse.status === 200) {
+                bc.identity.getChildProfiles(true, (response) => {
+                    equal(response.status, 200, "Expecting 200");
+
+                    bc.playerState.logout((logoutResponse) => {
+                        equal(logoutResponse.status, 200, "Expecting 200");
+                        resolve_test();
+                    });
+                });
+            }
+            else {
+                resolve_test();
+            }
+        });
+    });
+
+    // GetExpiredIdentities
+    await asyncTest("testGetExpiredIdentities()", 2, function () {
+        bc.authenticateAnonymous((authResponse) => {
+            if (authResponse.status === 200) {
+                bc.identity.getExpiredIdentities((response) => {
+                    equal(response.status, 200, "Expecting 200");
+
+                    bc.playerState.logout((logoutResponse) => {
+                        equal(logoutResponse.status, 200, "Expecting 200");
+                        resolve_test();
+                    });
+                });
+            }
+            else {
+                resolve_test();
+            }
+        });
+    });
+
+    // GetIdentities
+    await asyncTest("testGetIdentities()", 2, function () {
+        bc.authenticateAnonymous((authResponse) => {
+            if (authResponse.status === 200) {
+                bc.identity.getIdentities((response) => {
+                    equal(response.status, 200, "Expecting 200");
+
+                    bc.playerState.logout((logoutResponse) => {
+                        equal(logoutResponse.status, 200, "Expecting 200");
+                        resolve_test();
+                    });
+                });
+            }
+            else {
+                resolve_test();
+            }
+        });
+    });
+
+    // TODO:  GetIdentityStatus
+    // TODO: getIdentityStatus is not a function
+    // await asyncTest("testGetIdentityStatus()", 2, function () {
+
+    //     bc.authenticateAnonymous((authResponse) => {
+    //         if (authResponse.status === 200) {
+    //             //
+    //             var authenticationType = bc.identity.authenticationType.email;
+    //             var externalAuthName = "";
+
+    //             bc.identity.getIdentityStatus(authenticationType, externalAuthName, (response) => {
+    //                 equal(response.status, 200, " Expecting Successful Response");
+
+    //                 bc.playerState.logout((logoutResponse) => {
+    //                     equal(logoutResponse.status, 200, " Expecting Successful Logout");
+    //                     resolve_test();
+    //                 });
+    //             });
+    //         }
+    //         else {
+    //             console.log("Initial authentication failed. Test cannot proceed.");
+    //             resolve_test();
+    //         }
+    //     });
+    // });
+
+    // TODO:  GetPeerProfiles
+    await asyncTest("testGetPeerProfiles()", 2, function () {
+        
+        bc.authenticateAnonymous((authResponse) => {
+            if(authResponse.status === 200){
+                bc.identity.getPeerProfiles((response) => {
+                    equal(response.status, 200, " Expecting Successful Response");
+
+                    bc.playerState.logout((logoutResponse) => {
+                        equal(logoutResponse.status, 200, " Expecting Successful Logout");
+                        resolve_test();
+                    });
+                });
+            }
+            else{
+                console.log("Initial authentication failed. Test cannot proceed.");
+                resolve_test();
+            }
+        });
+    });
+
+    // TODO:  MergeAdvancedIdentity
+    // TODO:  MergeAppleIdentity
+
+    // MergeEmailIdentity
+    await asyncTest("testMergeEmailIdentity()", 1, function () {
+        var mergeEmail = "merge" + email;
+
+
+        bc.authenticateEmailPassword(mergeEmail, password, true, () => {
+            bc.playerState.logout(() => {
+                bc.authenticateUniversal(universalId, password, true, (authResponse) => {
+                    if (authResponse.status === 200) {
+                        bc.identity.mergeEmailIdentity(mergeEmail, password, (mergeResponse) => {
+                            equal(mergeResponse.status, 200, " Expecting Successful Merge");
+
+                            bc.playerState.logout(() => {
+                                resolve_test();
+                            })
+                        });
+                    }
+                    else {
+                        console.log("Authentication failed. Test cannot proceed.");
+                        resolve_test();
+                    }
+                });
+            });
+        });
+    });
+
+    // TODO:  MergeFacebookIdentity
+    // TODO:  MergeFacebookLimitedIdentity
+    // TODO:  MergeGameCenterIdentity
+    // TODO:  MergeGoogleIdentity
+    // TODO:  MergeGoogleOpenIdIdentity
+    // TODO:  MergeParseIdentity
+    // TODO:  MergeSteamIdentity
+    // TODO:  MergeTwitterIdentity
+    // TODO:  MergeUltraIdentity
+
+    // MergeUniversalIdentity
+    await asyncTest("testMergeUniversalIdentity()", 1, function () {
+        var mergeUniversalId = "merge" + universalId;
+        
+        bc.authenticateUniversal(mergeUniversalId, password, true, () => {
+            bc.playerState.logout(() => {
+                bc.authenticateEmailPassword(email, password, true, (authResponse) => {
+                    if (authResponse.status === 200) {
+                        bc.identity.mergeUniversalIdentity(mergeUniversalId, password, (mergeResponse) => {
+                            equal(mergeResponse.status, 200, " Expecting Successful Merge");
+
+                            bc.playerState.logout(() => {
+                                resolve_test();
+                            })
+                        });
+                    }
+                    else {
+                        console.log("Authentication failed. Test cannot proceed.");
+                        resolve_test();
+                    }
+                });
+            });
+        });
+    });
+
+    // TODO:  RefreshIdentity
+    // TODO:  intended for things like facebook:
+    //          we get a token that is used for requests but this token can expire so we would need to refresh
+    // await asyncTest("testRefreshIdentity()", 1, function () {
+    //     bc.resetStoredProfileId();
+
+    //     bc.authenticateAnonymous((authResponse) => {
+    //         if(authResponse.status === 200){
+    //             var authenticationType = bc.identity.authenticationType.universal
+                
+    //             bc.identity.refreshIdentity(universalId, password, authenticationType, (response) => {
+    //                 equal(response.status, 200, " Expecting Successful Response");
+
+    //                 bc.playerState.logout(() => {
+    //                     resolve_test();
+    //                 });
+    //             });
+    //         }
+    //         else{
+    //             console.log("Initial authentication failed. Test cannot proceed.");
+    //             resolve_test();
+    //         }
+    //     });
+    // });
+
+    // SwitchToParentProfile
+    await asyncTest("testSwitchToSingletonChildAndParentProfile()", 2, () => {
+        bc.resetStoredProfileId();
+
+        initializeClient();
+
+        bc.authenticateUniversal(UserA.name, UserA.password, true, authResponse => {
+            if(authResponse.status === 200){
+                bc.identity.switchToSingletonChildProfile(CHILD_APP_ID, true, switchToChildResponse => {
+                    equal(switchToChildResponse.status, 200, " Expecting successful switch")
+
+                    bc.identity.switchToParentProfile(PARENT_LEVEL_NAME, switchToParentResponse => {
+                        equal(switchToParentResponse.status, 200, " Expecting successful switch")
+
+                        bc.playerState.logout(() => {
+                            resolve_test()
+                        })
+                    })
+                })
+            }
+            else{
+                console.log("Authentication failed. Test cannot proceed.")
+                resolve_test()
+            }
+        })
+    })
+
+    // UpdateUniversalIdLogin
+    await asyncTest("testUpdateUniversalIdLogin()", 1, () => {
+        bc.authenticateUniversal(universalId, password, true, authResponse => {
+            if(authResponse.status === 200){
+                bc.identity.updateUniversalIdLogin(universalId + "Updated", response => {
+                    equal(response.status, 200, " Expecting successful update")
+
+                    bc.playerState.logout(() => {
+                        resolve_test()
+                    })
+                })
+            }
+            else{
+                console.log("Authentication failed. Test cannot proceed.")
+                resolve_test()
+            }
+        })
+    })
+}
+
 ////////////////////////////////////////
 // Identity tests
 ////////////////////////////////////////
@@ -5493,6 +6022,9 @@ async function testTournament() {
 ////////////////////////////////////////
 async function testSharedIdentity() {
 
+
+    // TODO:  remove following tests after refactoring
+
     initializeClient();
 
     if (!module("SharedIdentity", null, null)) return;
@@ -7667,6 +8199,7 @@ async function run_tests()
     await testGroupFile();
     await testGroup();
     await testIdentity();
+    await testNewIdentity();    // TODO
     await testMail();
     await testMatchMaking();
     await testOneWayMatch();


### PR DESCRIPTION
- Created new Identity test suite
   - Removed separated Identity/Shared Identity tests
   - Added new tests for APIs that were not previously being tested
   - Tests are now more independent
      - DetachParent test was failing/hanging resulting in incomplete test runs
      - One failing test should no longer result in consecutive tests failing
- Corrected bug in attachAdvancedIdentity function
   - Condition statement for adding additional JSON to request was not checking the right parameter
- Added getIdentityStatus function

This branch has been the default on Jenkins for several days. Green test: https://vmjenkins.bitheads.com/view/Dev_Javascript/job/bitHeads_BrainCloud_Client_UnitTest_JavaScript_develop_internal/3620/consoleFull