### PR TITLE
Missing APIs for 5.5

### DIFF
--- a/src/brainCloudBase.js
+++ b/src/brainCloudBase.js
@@ -834,7 +834,8 @@ function BrainCloudManager ()
                 {
                     if (bcm._inProgressQueue[i].operation == "AUTHENTICATE" || 
                         bcm._inProgressQueue[i].operation == "RESET_EMAIL_PASSWORD" || 
-                        bcm._inProgressQueue[i].operation == "RESET_EMAIL_PASSWORD_ADVANCED")
+                        bcm._inProgressQueue[i].operation == "RESET_EMAIL_PASSWORD_ADVANCED" ||
+                        bcm._inProgressQueue[i].operation == "GET_SERVER_VERSION")
                     {
                         isAuth = true;
                         break;

--- a/src/brainCloudClient-events.js
+++ b/src/brainCloudClient-events.js
@@ -7,6 +7,7 @@ function BCEvents() {
 	bc.SERVICE_EVENT = "event";
 
 	bc.event.OPERATION_SEND = "SEND";
+	bc.event.OPERATION_SEND_EVENT_TO_PROFILES = "SEND_EVENT_TO_PROFILES";
 	bc.event.OPERATION_UPDATE_EVENT_DATA = "UPDATE_EVENT_DATA";
 	bc.event.OPERATION_UPDATE_EVENT_DATA_IF_EXISTS = "UPDATE_EVENT_DATA_IF_EXISTS";
 	bc.event.OPERATION_DELETE_INCOMING = "DELETE_INCOMING";
@@ -47,6 +48,32 @@ function BCEvents() {
 			service: bc.SERVICE_EVENT,
 			operation: bc.event.OPERATION_SEND,
 			data: message,
+			callback: callback
+		});
+	};
+
+	/**
+	 * Sends an event to multiple users with the attached json data.
+	 * 
+	 * Service Name - Event
+	 * Service Operation - SEND_EVENT_TO_PROFILES
+	 * 
+	 * @param toIds The profile ids of the users to send the event
+	 * @param eventType The user-defined type of the event
+	 * @param eventData The user-defined data for this event encoded in JSON
+	 * @param callback The method to be invoked when the server response is received
+	 */
+	bc.event.sendEventToProfiles = function (toIds, eventType, eventData, callback) {
+		var data = {
+			toIds: toIds,
+			eventType: eventType,
+			evemtData: eventData
+		};
+
+		bc.brainCloudManager.sendRequest({
+			service: bc.SERVICE_EVENT,
+			operation: bc.event.OPERATION_SEND_EVENT_TO_PROFILES,
+			data: data,
 			callback: callback
 		});
 	};

--- a/src/brainCloudClient-friend.js
+++ b/src/brainCloudClient-friend.js
@@ -8,6 +8,7 @@ function BCFriend() {
 
 	bc.friend.OPERATION_GET_FRIEND_PROFILE_INFO_FOR_EXTERNAL_ID = "GET_FRIEND_PROFILE_INFO_FOR_EXTERNAL_ID";
 	bc.friend.OPERATION_GET_PROFILE_INFO_FOR_CREDENTIAL = "GET_PROFILE_INFO_FOR_CREDENTIAL";
+	bc.friend.OPERATION_GET_PROFILE_INFO_FOR_CREDENTIAL_IF_EXISTS = "GET_PROFILE_INFO_FOR_CREDENTIAL_IF_EXISTS";
 	bc.friend.OPERATION_GET_PROFILE_INFO_FOR_EXTERNAL_AUTH_ID = "GET_PROFILE_INFO_FOR_EXTERNAL_AUTH_ID";
 	bc.friend.OPERATION_GET_EXTERNAL_ID_FOR_PROFILE_ID = "GET_EXTERNAL_ID_FOR_PROFILE_ID";
 	bc.friend.OPERATION_READ_FRIENDS = "READ_FRIENDS";
@@ -49,6 +50,28 @@ function BCFriend() {
 			data : {
 				externalId : externalId,
 				authenticationType : authenticationType
+			},
+			callback: callback
+		});
+	};
+
+	/**
+	 * Retrieves profile information for the specified user. Silently fails, if profile does not exist, just returns null and success, instead of an error.
+	 *
+	 * Service Name - friend
+	 * Service Operation - GET_PROFILE_INFO_FOR_CREDENTIAL_IF_EXISTS
+	 *
+	 * @param externalId The users's external ID
+	 * @param authenticationType The authentication type of the user ID
+	 * @param callback Method to be invoked when the server response is received.
+	 */
+	bc.friend.getProfileInfoForCredentialIfExists = function (externalId, authenticationType, callback) {
+		bc.brainCloudManager.sendRequest({
+			service: bc.SERVICE_FRIEND,
+			operation: bc.friend.OPERATION_GET_PROFILE_INFO_FOR_CREDENTIAL_IF_EXISTS,
+			data: {
+				externalId: externalId,
+				authenticationType: authenticationType
 			},
 			callback: callback
 		});

--- a/src/brainCloudClient-friend.js
+++ b/src/brainCloudClient-friend.js
@@ -10,6 +10,7 @@ function BCFriend() {
 	bc.friend.OPERATION_GET_PROFILE_INFO_FOR_CREDENTIAL = "GET_PROFILE_INFO_FOR_CREDENTIAL";
 	bc.friend.OPERATION_GET_PROFILE_INFO_FOR_CREDENTIAL_IF_EXISTS = "GET_PROFILE_INFO_FOR_CREDENTIAL_IF_EXISTS";
 	bc.friend.OPERATION_GET_PROFILE_INFO_FOR_EXTERNAL_AUTH_ID = "GET_PROFILE_INFO_FOR_EXTERNAL_AUTH_ID";
+	bc.friend.OPERATION_GET_PROFILE_INFO_FOR_EXTERNAL_AUTH_ID_IF_EXISTS = "GET_PROFILE_INFO_FOR_EXTERNAL_AUTH_ID_IF_EXISTS";
 	bc.friend.OPERATION_GET_EXTERNAL_ID_FOR_PROFILE_ID = "GET_EXTERNAL_ID_FOR_PROFILE_ID";
 	bc.friend.OPERATION_READ_FRIENDS = "READ_FRIENDS";
 	bc.friend.OPERATION_READ_FRIEND_ENTITY = "READ_FRIEND_ENTITY";
@@ -94,6 +95,29 @@ function BCFriend() {
 			data : {
 				externalId : externalId,
 				externalAuthType : externalAuthType
+			},
+			callback: callback
+		});
+	};
+
+	/**
+	 * Retrieves profile information for the specified user.
+	 * Silently fails, if profile does not exist, just returns null and success, instead of an error.
+	 *
+	 * Service Name - Friend
+	 * Service Operation - GET_PROFILE_INFO_FOR_EXTERNAL_AUTH_ID_IF_EXISTS
+	 *
+	 * @param externalId External ID of the friend to find
+	 * @param externalAuthType The external authentication type used for this friend's external ID
+	 * @param callback Method to be invoked when the server response is received.
+	 */
+	bc.friend.getProfileInfoForExternalAuthIdIfExists = function (externalId, externalAuthType, callback) {
+		bc.brainCloudManager.sendRequest({
+			service: bc.SERVICE_FRIEND,
+			operation: bc.friend.OPERATION_GET_PROFILE_INFO_FOR_EXTERNAL_AUTH_ID_IF_EXISTS,
+			data: {
+				externalId: externalId,
+				externalAuthType: externalAuthType
 			},
 			callback: callback
 		});

--- a/src/brainCloudClient-group.js
+++ b/src/brainCloudClient-group.js
@@ -39,6 +39,7 @@ function BCGroup() {
     bc.group.OPERATION_SET_GROUP_OPEN = "SET_GROUP_OPEN";
     bc.group.OPERATION_UPDATE_GROUP_ACL = "UPDATE_GROUP_ACL";
     bc.group.OPERATION_UPDATE_GROUP_DATA = "UPDATE_GROUP_DATA";
+    bc.group.OPERATION_UPDATE_GROUP_ENTITY_ACL = "UPDATE_GROUP_ENTITY_ACL";
     bc.group.OPERATION_UPDATE_GROUP_ENTITY = "UPDATE_GROUP_ENTITY_DATA";
     bc.group.OPERATION_UPDATE_GROUP_MEMBER = "UPDATE_GROUP_MEMBER";
     bc.group.OPERATION_UPDATE_GROUP_NAME = "UPDATE_GROUP_NAME";
@@ -868,6 +869,29 @@ function BCGroup() {
             callback : callback
         });
     };
+
+    /**
+     * Update the acl settings for a group entity, enforcing ownership.
+     * 
+     * @param groupId The id of the group
+     * @param entityId The id of the entity to update
+     * @param acl Access control list for the group entity
+     * @param callback The method to be invoked when the server response is received
+     */
+    bc.group.updateGroupEntityAcl = function (groupId, entityId, acl, callback) {
+        var message = {
+            groupId: groupId,
+            entityId: entityId,
+            acl : acl
+        }
+
+        bc.brainCloudManager.sendRequest({
+            service: bc.SERVICE_GROUP,
+            operation: bc.group.OPERATION_UPDATE_GROUP_ENTITY_ACL,
+            data: message,
+            callback: callback
+        })
+    }
 
     /**
      * Update a group entity.

--- a/src/brainCloudClient-group.js
+++ b/src/brainCloudClient-group.js
@@ -845,6 +845,30 @@ function BCGroup() {
     };
 
     /**
+     * Set a group's access conditions.
+     * 
+     * Service Name - Group
+     * Service Operation - UPDATE_GROUP_ACL
+     * 
+     * @param groupId ID of the group
+     * @param acl The group's access control list. A null ACL implies default
+     * @param callback The method to be invoked when the server response is received
+     */
+    bc.group.updateGroupAcl = function (groupId, acl, callback) {
+        var data = {
+            groupId: groupId,
+            acl: acl
+        };
+
+        bc.brainCloudManager.sendRequest({
+            service: bc.SERVICE_GROUP,
+            operation: bc.group.OPERATION_UPDATE_GROUP_ACL,
+            data: data,
+            callback: callback
+        });
+    }
+
+    /**
      * Updates a group's data.
      *
      * Service Name - group

--- a/src/brainCloudClient-mail.js
+++ b/src/brainCloudClient-mail.js
@@ -9,6 +9,7 @@ function BCMail() {
     bc.mail.OPERATION_SEND_BASIC_EMAIL = "SEND_BASIC_EMAIL";
     bc.mail.OPERATION_SEND_ADVANCED_EMAIL = "SEND_ADVANCED_EMAIL";
     bc.mail.OPERATION_SEND_ADVANCED_EMAIL_BY_ADDRESS = "SEND_ADVANCED_EMAIL_BY_ADDRESS";
+    bc.mail.OPERATION_SEND_ADVANCED_EMAIL_BY_ADDRESSES = "SEND_ADVANCED_EMAIL_BY_ADDRESSES";
 
     /**
      * Sends a simple text email to the specified player
@@ -74,6 +75,28 @@ function BCMail() {
             operation: bc.mail.OPERATION_SEND_ADVANCED_EMAIL_BY_ADDRESS,
             data: {
                 emailAddress: emailAddress,
+                serviceParams: serviceParams
+            },
+            callback: callback
+        });
+    };
+
+    /**
+     * Sends an advanced email to the specified email addresses
+     *
+     * Service Name - Mail
+     * Service Operation - SEND_ADVANCED_EMAIL_BY_ADDRESSES
+     *
+     * @param emailAddresses The list of addresses to send the email to
+     * @param serviceParams Set of parameters dependant on the mail service configured
+     * @param in_callback The method to be invoked when the server response is received
+     */
+    bc.mail.sendAdvancedEmailByAddresses = function (emailAddresses, serviceParams, callback) {
+        bc.brainCloudManager.sendRequest({
+            service: bc.SERVICE_MAIL,
+            operation: bc.mail.OPERATION_SEND_ADVANCED_EMAIL_BY_ADDRESSES,
+            data: {
+                emailAddresses: emailAddresses,
                 serviceParams: serviceParams
             },
             callback: callback

--- a/src/brainCloudClient-playback-stream.js
+++ b/src/brainCloudClient-playback-stream.js
@@ -179,6 +179,15 @@ function BCPlaybackStream() {
         });
     };
 
+    /**
+     * Protects a playback stream from being purged (but not deleted) for the given number of days (from now). 
+     * If the number of days given is less than the normal purge interval days (from createdAt), the longer protection date is applied. 
+     * Can only be called by users involved in the playback stream.
+     * 
+     * @param playbackStreamId Identifies the stream to protect
+     * @param numDays The number of days the stream is to be protected (from now)
+     * @param callback The method to be invoked when the server response is received
+     */
     bc.playbackStream.protectStreamUntil = function(playbackStreamId, numDays, callback){
         var message = {
             playbackStreamId : playbackStreamId,

--- a/src/brainCloudClient-playback-stream.js
+++ b/src/brainCloudClient-playback-stream.js
@@ -15,6 +15,7 @@ function BCPlaybackStream() {
     bc.playbackStream.OPERATION_GET_STREAM_SUMMARIES_FOR_TARGET_PLAYER = "GET_STREAM_SUMMARIES_FOR_TARGET_PLAYER";
     bc.playbackStream.OPERATION_GET_RECENT_STREAMS_FOR_INITIATING_PLAYER = "GET_RECENT_STREAMS_FOR_INITIATING_PLAYER";
     bc.playbackStream.OPERATION_GET_RECENT_STREAMS_FOR_TARGET_PLAYER = "GET_RECENT_STREAMS_FOR_TARGET_PLAYER";
+    bc.playbackStream.OPERATION_PROTECT_STREAM_UNTIL = "PROTECT_STREAM_UNTIL";
 
     /**
      * Method starts a new playback stream.
@@ -177,6 +178,20 @@ function BCPlaybackStream() {
             callback : callback
         });
     };
+
+    bc.playbackStream.protectStreamUntil = function(playbackStreamId, numDays, callback){
+        var message = {
+            playbackStreamId : playbackStreamId,
+            numDays : numDays
+        }
+
+        bc.brainCloudManager.sendRequest({
+            service : bc.SERVICE_PLAYBACK_STREAM,
+            operation : bc.playbackStream.OPERATION_PROTECT_STREAM_UNTIL,
+            data : message,
+            callback : callback
+        })
+    }
 
 }
 

--- a/src/brainCloudClient-social-leaderboards.js
+++ b/src/brainCloudClient-social-leaderboards.js
@@ -40,6 +40,7 @@ function BCSocialLeaderboard() {
     bc.socialLeaderboard.OPERATION_GET_GROUP_LEADERBOARD_VIEW = "GET_GROUP_LEADERBOARD_VIEW";
     bc.socialLeaderboard.OPERATION_GET_GROUP_LEADERBOARD_VIEW_BY_VERSION = "GET_GROUP_LEADERBOARD_VIEW_BY_VERSION";
     bc.socialLeaderboard.OPERATION_POST_SCORE_TO_DYNAMIC_GROUP_LEADERBOARD = "POST_GROUP_SCORE_DYNAMIC"
+    bc.socialLeaderboard.OPERATION_POST_SCORE_TO_DYNAMIC_GROUP_LEADERBOARD_USING_CONFIG = "POST_GROUP_SCORE_DYNAMIC_USING_CONFIG"
 
 
 
@@ -806,6 +807,35 @@ function BCSocialLeaderboard() {
                 },
                 callback : callback
             });
+    };
+
+    /**
+     * Post the group's score to the given social leaderboard, dynamically creating the group leaderboard if it does not exist yet.
+     * To create new leaderboard, configJson must specify leaderboardType, rotationType, resetAt, and retainedCount, at a minimum, with support to optionally specify an expiry in minutes.
+     * 
+     * Service Name - Leaderboard
+     * Service Operation - POST_GROUP_SCORE_DYNAMIC_USING_CONFIG
+     * 
+     * @param leaderboardId The leaderboard to post to
+     * @param groupId The id of the group
+     * @param score A score to post
+     * @param scoreData Optional user-defined data to post with the score
+     * @param configJson Configuration for the leaderboard if it does not exist yet, specified as JSON object. The supporting configuration fields are listed in the following table of configJson fields
+     * @param callback The method to be invoked when the server response is received
+     */
+    bc.socialLeaderboard.postScoreToDynamicGroupLeaderboardUsingConfig = function (leaderboardId, groupId, score, scoreData, configJson, callback) {
+        bc.brainCloudManager.sendRequest({
+            service: bc.SERVICE_LEADERBOARD,
+            operation: bc.socialLeaderboard.OPERATION_POST_SCORE_TO_DYNAMIC_GROUP_LEADERBOARD_USING_CONFIG,
+            data: {
+                leaderboardId: leaderboardId,
+                groupId: groupId,
+                score: score,
+                scoreData: scoreData,
+                configJson: configJson
+            },
+            callback: callback
+        });
     };
 
     /**

--- a/test/test.js
+++ b/test/test.js
@@ -3048,6 +3048,18 @@ async function testGroup() {
                 });
     });
 
+    await asyncTest("testUpdateGroupAcl()", 1, function () {
+        var acl = {
+            "other": 2,
+            "member": 2
+        }
+
+        bc.group.updateGroupAcl(groupId, acl, function (response) {
+            equal(response.status, 200, "Expecting 200");
+            resolve_test();
+        });
+    });
+
     await asyncTest("deleteGroup()", 2, function() {
         bc.group.deleteGroup(
                 groupId,

--- a/test/test.js
+++ b/test/test.js
@@ -3739,11 +3739,16 @@ async function testMail() {
     });
 
     await asyncTest("sendAdvancedEmailByAddresses()", 1, function () {
-        var emailAddresses = ["bc-client-team@bitheads.com"];
+        var emailAddresses = ["testemail@email.com"];
         var serviceParams = {
-            subject: "Test Subject - TestSendAdvancedEmailSendGrid",
-            body: "Test body content message.",
-            categories: ["unit-test"]
+            fromAddress: "testemail@email.com",
+            fromName: "James Reece",
+            subject: "Advanced Email Test",
+            body: "Advanced Email Test",
+            replyToAddress: "",
+            replyToName: "",
+            categories: [],
+            attachments: []
         }
 
         bc.mail.sendAdvancedEmailByAddresses(

--- a/test/test.js
+++ b/test/test.js
@@ -3973,6 +3973,15 @@ async function testPlaybackStream() {
             });
     });
 
+    await asyncTest("protectStreamUntil()", 1, function () {
+        bc.playbackStream.protectStreamUntil(streamId, 1, (response) => {
+            if (response.status === 200) {
+                equal(response.status, 200, "Expecting 200")
+            }
+            resolve_test()
+        })
+    })
+
     await asyncTest("deleteStream()", 2, function() {
         bc.playbackStream.deleteStream(
                 streamId,

--- a/test/test.js
+++ b/test/test.js
@@ -1689,6 +1689,15 @@ async function testFriend() {
                 });
     });
 
+    await asyncTest("getProfileInfoForExternalAuthIdIfExists()", 2, function () {
+        bc.friend.getProfileInfoForExternalAuthIdIfExists(
+            UserA.profileId, "testExternal", function (result) {
+                ok(true, JSON.stringify(result));
+                equal(result.status, 200, "Expecting 200");
+                resolve_test();
+            });
+    });
+
     await asyncTest("getExternalIdForProfileId()", 2, function() {
         bc.friend.getExternalIdForProfileId(
                 UserA.profileId, "Facebook", function(result) {

--- a/test/test.js
+++ b/test/test.js
@@ -5383,6 +5383,30 @@ async function testSocialLeaderboard() {
             });
     });
 
+    await asyncTest("postScoreToDynamicGroupLeaderboardUsingConfig()", 1, function () {
+        var today = new Date();
+        var tomorrow = new Date(today);
+        tomorrow.setDate(today.getDate() + 1);
+        var leaderboardId = groupLeaderboard;
+        var score = 99;
+        var scoreData = {
+            "nickname": "tarnished"
+        };
+        var configJson = {
+            "leaderboardType": "HIGH_VALUE",
+            "rotationType": "DAYS",
+            "numDaysToRotate": 4,
+            "resetAt": tomorrow,
+            "retainedCount": 2,
+            "expireInMins": null
+        };
+
+        bc.leaderboard.postScoreToDynamicGroupLeaderboardUsingConfig(leaderboardId, groupId, score, scoreData, configJson, function (response) {
+            equal(response.status, 200, "Expecting 200");
+            resolve_test();
+        });
+    });
+
     await asyncTest("removeGroupScore())", 2, function() {
         bc.leaderboard.removeGroupScore(
             groupLeaderboard,

--- a/test/test.js
+++ b/test/test.js
@@ -1541,6 +1541,17 @@ async function testEvent() {
     });
 
     await setUpWithAuthenticate();
+    await asyncTest("sendEventToProfiles()", 1, function() {
+        var toIds = [UserA.profileId];
+        var eventData = {eventDataKey : 24};
+
+        bc.event.sendEventToProfiles(toIds, eventType, eventData, function(response) {
+            equal(response.status, 200, "Expecting 200");
+            resolve_test();
+        });
+    });
+
+    await setUpWithAuthenticate();
     await asyncTest("updateIncomingEventData()", function() {
         bc.event.updateIncomingEventData(
                 eventId,

--- a/test/test.js
+++ b/test/test.js
@@ -3738,6 +3738,20 @@ async function testMail() {
             });
     });
 
+    await asyncTest("sendAdvancedEmailByAddresses()", 1, function () {
+        var emailAddresses = ["bc-client-team@bitheads.com"];
+        var serviceParams = {
+            subject: "Test Subject - TestSendAdvancedEmailSendGrid",
+            body: "Test body content message.",
+            categories: ["unit-test"]
+        }
+
+        bc.mail.sendAdvancedEmailByAddresses(
+            emailAddresses, serviceParams, function (result) {
+                equal(result.status, 200, "Expecting 200");
+                resolve_test();
+            });
+    });
 
 }
 

--- a/test/test.js
+++ b/test/test.js
@@ -1660,6 +1660,15 @@ async function testFriend() {
                 });
     });
 
+    await asyncTest("getProfileInfoForCredentialIfExists()", 2, function() {
+        bc.friend.getProfileInfoForCredentialIfExists(
+                UserA.name, "Universal", function(result) {
+                    ok(true, JSON.stringify(result));
+                    equal(result.status, 200, "Expecting 200");
+                    resolve_test();
+                });
+    });
+
     await asyncTest("getProfileInfoForExternalAuthId()", 2, function() {
         bc.friend.getProfileInfoForExternalAuthId(
                 "externalId", "Facebook", function(result) {

--- a/test/test.js
+++ b/test/test.js
@@ -2800,11 +2800,16 @@ async function testGroup() {
     });
 
     await asyncTest("createGroupEntity()", 2, function() {
+        var acl = {
+            "other" : 2,
+            "member" : 2
+        }
+        
         bc.group.createGroupEntity(
                 groupId,
                 "test",
-                false,
-                null,
+                true,
+                acl,
                 testData,
                 function(result) {
                     ok(true, JSON.stringify(result));
@@ -2850,6 +2855,18 @@ async function testGroup() {
                     resolve_test();
                 });
     });
+
+    await asyncTest("updateGroupEntityAcl()", 1, function () {
+        var acl = {
+            "other": 2,
+            "member": 2
+        }
+
+        bc.group.updateGroupEntityAcl(groupId, entityId, acl, (response) => {
+            equal(response.status, 200, "Expecting 200")
+            resolve_test()
+        })
+    })
 
     await asyncTest("deleteGroupEntity()", 2, function() {
         bc.group.deleteGroupEntity(

--- a/test/test.js
+++ b/test/test.js
@@ -876,18 +876,15 @@ async function testAuthentication() {
         resetUniversalIDPassword(testResetUniversalIdPasswordAdvancedWithExpiry);
     });
 
-    await asyncTest("getServerVersion()", 2, function () {
+    await asyncTest("getServerVersion()", 1, function () {
         bc.brainCloudClient.authentication.initialize("", bc.brainCloudClient.authentication.generateAnonymousId());
 
-        bc.brainCloudClient.authentication.authenticateAnonymous(true, function (response) {
-            equal(response.status, 200, JSON.stringify(response))
-
-            bc.brainCloudClient.authentication.getServerVersion(function (response) {
-                if (response.status == 200) {
-                    ok(true, "Server Version Retrieved: " + response.data.serverVersion)
-                    resolve_test()
-                }
-            })
+        bc.brainCloudClient.authentication.getServerVersion(function (response) {
+            if (response.status == 200) {
+                ok(true, "Server Version Retrieved: " + response.data.serverVersion)
+                
+            }
+            resolve_test()
         })
     })
 


### PR DESCRIPTION
New APIs:
- GET_IDENTITY_STATUS
- GET_PROFILE_INFO_FOR_CREDENTIAL_IF_EXISTS
- GET_PROFILE_INFO_FOR_EXTERNAL_AUTH_ID_IF_EXISTS
- GET_SERVER_VERSION
- POST_GROUP_SCORE_DYNAMIC_USING_CONFIG
- PROTECT_STREAM_UNTIL
- SEND_ADVANCED_EMAIL_BY_ADDRESSES
- SEND_EVENT_TO_PROFILES
- UPDATE_GROUP_ACL
- UPDATE_GROUP_ENTITY_ACL

Green Test: https://vmjenkins.bitheads.com/view/Dev_Javascript/job/bitHeads_BrainCloud_Client_UnitTest_JavaScript_develop_internal/3711/