### PR TITLE
implemented compressIfLarger check

### DIFF
--- a/src/brainCloudBase.js
+++ b/src/brainCloudBase.js
@@ -68,6 +68,7 @@ function BrainCloudManager ()
     bcm._appVersion = "";
     bcm._debugEnabled = false;
     bcm._compressionEnabled = true;
+    bcm._compressionThreshold = 51200;
 
     bcm._requestInProgress = false;
     bcm._bundleDelayActive = false;
@@ -438,20 +439,19 @@ function BrainCloudManager ()
                     bcm._sessionId = "";
                     bcm.authentication.profileId = "";
                 }
-                else if (bcm._inProgressQueue[c].operation == "AUTHENTICATE")
-                {
+                else if (bcm._inProgressQueue[c].operation == "AUTHENTICATE") {
                     bcm._isAuthenticated = true;
-                    if (data.hasOwnProperty("playerSessionExpiry"))
-                    {
+                    if (data.hasOwnProperty("playerSessionExpiry")) {
                         bcm._idleTimeout = data.playerSessionExpiry * 0.85;
                     }
-                    else
-                    {
+                    else {
                         bcm._idleTimeout = 30;
                     }
-                    if(data.hasOwnProperty("maxKillCount"))
-                    {
+                    if (data.hasOwnProperty("maxKillCount")) {
                         bcm._killSwitchThreshold = data.maxKillCount;
+                    }
+                    if (data.hasOwnProperty("compressIfLarger")) {
+                        bcm._compressionThreshold = data.compressIfLarger;
                     }
                     bcm.resetErrorCache();
                     bcm.startHeartBeat();
@@ -708,7 +708,10 @@ function BrainCloudManager ()
         xmlhttp.setRequestHeader("X-SIG", sig);
         xmlhttp.setRequestHeader('X-APPID', bcm._appId);
 
-        if (bcm._compressionEnabled) {
+        // Used to check if request should be compressed
+        var requestSize = new TextEncoder().encode(bcm._jsonedQueue).length;
+
+        if (bcm._compressionEnabled && bcm._compressionThreshold >= 0 && requestSize >= bcm._compressionThreshold) {
             bcm.compressRequest(bcm._jsonedQueue)
                 .then(function (compressedData) {
                     fetch(bcm._dispatcherUrl, {

--- a/src/brainCloudBase.js
+++ b/src/brainCloudBase.js
@@ -87,10 +87,8 @@ function BrainCloudManager ()
     bcm._isInitialized = false;
     bcm._isAuthenticated = false;
 
-    bcm.compressRequest = function(requestToCompress) {    
-        var encodedData = new TextEncoder().encode(requestToCompress);
-    
-        var compressionStream = new Blob([encodedData]).stream().pipeThrough(new CompressionStream("gzip"));
+    bcm.compressRequest = function(requestToCompress) {        
+        var compressionStream = new Blob([requestToCompress]).stream().pipeThrough(new CompressionStream("gzip"));
     
         return new Response(compressionStream).blob()
             .then(function(compressedBlob) {
@@ -709,10 +707,11 @@ function BrainCloudManager ()
         xmlhttp.setRequestHeader('X-APPID', bcm._appId);
 
         // Used to check if request should be compressed
-        var requestSize = new TextEncoder().encode(bcm._jsonedQueue).length;
+        var encodedRequest = new TextEncoder().encode(bcm._jsonedQueue);
+        var requestSize = encodedRequest.length;
 
         if (bcm._compressionEnabled && bcm._compressionThreshold >= 0 && requestSize >= bcm._compressionThreshold) {
-            bcm.compressRequest(bcm._jsonedQueue)
+            bcm.compressRequest(encodedRequest)
                 .then(function (compressedData) {
                     fetch(bcm._dispatcherUrl, {
                         method: "POST",


### PR DESCRIPTION
- Implemented BCLOUD-12432:
   - Added `compressionThreshold` int to control which messages should be compressed
   - Default `compressionThreshold` is 51200 bytes but is overridden by `compressIfLarger` field in AUTHENTICATION response
- Encoding for compressed requests has been removed from the compress function as it is now encoded when verifying request size


Green Test: https://vmjenkins.bitheads.com/view/Dev_Javascript/job/bitHeads_BrainCloud_Client_UnitTest_JavaScript_develop_internal/4068/consoleFull
