### PR TITLE
BCLOUD-13977: browser-friendly JS client (serverUrl init, browser bundle, auth-type fix)

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,11 @@ _bc.initialize(_appId, _secret, _appVersion);
 ```
 Your _appId, _secret, is set on the brainCloud dashboard. Under Design | Core App Info > Application IDs
 
+`initialize()` targets the brainCloud production servers by default. To target a different environment, pass the optional 4th `serverUrl` argument:
+```js
+_bc.initialize(_appId, _secret, _appVersion, "https://api.braincloudservers.com/dispatcherv2");
+```
+
 ![wrapper](/Screenshots/bc-ids.png?raw=true)
 
 _wrapperName prefixes saved operations that the wrapper will make. Use a _wrapperName if you plan on having multiple instances of brainCloud running.

--- a/deploy/browser/.gitignore
+++ b/deploy/browser/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+build/
+lib/
+package-lock.json

--- a/deploy/browser/README.md
+++ b/deploy/browser/README.md
@@ -37,8 +37,11 @@ Outputs (git-ignored, generated):
 <script>
   var bc = new BrainCloudWrapper("myApp");
   bc.initialize(appId, appSecret, appVersion);
-  // initialize() targets production by default; for any other cluster set the server URL:
-  bc.brainCloudClient.setServerUrl("https://api.braincloudservers.com/dispatcherv2");
+  // initialize() targets production by default; to target another cluster, pass the server
+  // URL as the optional 4th argument (preferred):
+  // bc.initialize(appId, appSecret, appVersion, "https://api.braincloudservers.com/dispatcherv2");
+  // ...or set it explicitly after initialize():
+  // bc.brainCloudClient.setServerUrl("https://api.braincloudservers.com/dispatcherv2");
   bc.authenticateAnonymous(function (r) { console.log(r.status); });
 </script>
 ```

--- a/deploy/browser/README.md
+++ b/deploy/browser/README.md
@@ -1,0 +1,55 @@
+# brainCloud JS — browser bundle
+
+Produces a **self-contained browser build** of the brainCloud JavaScript client: a single
+file you load with one `<script>` tag, with **no external CryptoJS** and **no `require` /
+`exports` shims**.
+
+## Why this exists
+
+The default web/node distribution (`autobuild/build_js.sh`) is just `cat src/*.js` with two
+`exports.*` lines appended. The source still contains Node `require()` calls for `crypto-js`,
+`get-user-locale`, `form-data` and `buffer`. That runs fine under Node, but in a browser the
+plain concat throws `require is not defined` / `exports is not defined`, so developers have to
+hand-roll a CryptoJS global and a `require` shim before it works.
+
+This build resolves those dependencies through [esbuild]:
+
+- `crypto-js`, `get-user-locale`, `buffer` are **bundled in**.
+- `form-data` is mapped to the browser-native `FormData` (see `shims/form-data.js`).
+- output is an **IIFE** that assigns `window.BrainCloudWrapper` and `window.BrainCloudClient`.
+
+## Build
+
+```bash
+cd deploy/browser
+./build.sh           # npm install + node build.mjs
+```
+
+Outputs (git-ignored, generated):
+
+- `lib/brainCloudClient.browser.js` — readable
+- `lib/brainCloudClient.browser.min.js` — minified (~343 KB)
+
+## Use in a browser
+
+```html
+<script src="brainCloudClient.browser.min.js"></script>
+<script>
+  var bc = new BrainCloudWrapper("myApp");
+  bc.initialize(appId, appSecret, appVersion);
+  // initialize() targets production by default; for any other cluster set the server URL:
+  bc.brainCloudClient.setServerUrl("https://api.braincloudservers.com/dispatcherv2");
+  bc.authenticateAnonymous(function (r) { console.log(r.status); });
+</script>
+```
+
+No other `<script>` tags, no bundler, no shims.
+
+## Notes
+
+- The build emits one harmless warning — a duplicate `twitter` key in an auth-type map in the
+  source (`brainCloudClient-authentication.js`); it does not affect output.
+- Source of truth is still `src/*.js`; this only repackages it for the browser. Keep it in sync
+  by re-running `./build.sh` whenever the client is released.
+
+[esbuild]: https://esbuild.github.io/

--- a/deploy/browser/build.mjs
+++ b/deploy/browser/build.mjs
@@ -1,0 +1,69 @@
+// Builds a self-contained browser bundle of the brainCloud JS client.
+//
+// The default web/node distribution (autobuild/build_js.sh) is just `cat src/*.js`, which
+// leaves Node `require()` calls (crypto-js, get-user-locale, form-data, buffer) and an
+// appended `exports.*` in the output. That only runs under Node — in a browser it throws
+// "require is not defined" / "exports is not defined".
+//
+// This build resolves those dependencies through esbuild and emits an IIFE that exposes
+// window.BrainCloudWrapper / window.BrainCloudClient, so it works from a single <script>
+// tag with NO external CryptoJS and NO require/exports shims.
+
+import { build } from 'esbuild';
+import { readdirSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { createRequire } from 'node:module';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const req = createRequire(import.meta.url);
+const srcDir = join(here, '..', '..', 'src');
+const buildDir = join(here, 'build');
+const outDir = join(here, 'lib');
+mkdirSync(buildDir, { recursive: true });
+mkdirSync(outDir, { recursive: true });
+
+// 1. Assemble the CommonJS concat from src/ (same source set as the web/node build).
+const files = readdirSync(srcDir).filter(f => f.endsWith('.js')).sort();
+let concat = files.map(f => readFileSync(join(srcDir, f), 'utf8')).join('\n');
+// The src files define BrainCloudWrapper / BrainCloudClient as top-level functions; expose
+// them as CommonJS exports so esbuild can treat the concat as the bundle's entry module.
+concat += '\n\nexports.BrainCloudWrapper = BrainCloudWrapper;\nexports.BrainCloudClient = BrainCloudClient;\n';
+const entry = join(buildDir, 'brainCloudClient.concat.js');
+writeFileSync(entry, concat);
+
+// 2. Map Node-only specifiers to browser-friendly ones:
+//    - form-data        -> native FormData (browsers ship it)
+//    - buffer / buffer/  -> the browser-safe `buffer` npm package
+const browserResolve = {
+  name: 'browser-resolve',
+  setup(b) {
+    b.onResolve({ filter: /^form-data$/ },
+      () => ({ path: join(here, 'shims', 'form-data.js') }));
+    // Resolve a subpath (not bare "buffer") so we get the npm package, not Node's core module.
+    b.onResolve({ filter: /^buffer\/?$/ },
+      () => ({ path: req.resolve('buffer/index.js') }));
+  },
+};
+
+// Re-expose the classes as browser globals (the classic API) alongside the IIFE return value.
+const footer = {
+  js: 'if(typeof window!=="undefined"){window.BrainCloudWrapper=brainCloud.BrainCloudWrapper;'
+    + 'window.BrainCloudClient=brainCloud.BrainCloudClient;}',
+};
+
+const common = {
+  entryPoints: [entry],
+  bundle: true,
+  platform: 'browser',
+  format: 'iife',
+  globalName: 'brainCloud',
+  plugins: [browserResolve],
+  footer,
+  logLevel: 'info',
+};
+
+await build({ ...common, outfile: join(outDir, 'brainCloudClient.browser.js') });
+await build({ ...common, minify: true, outfile: join(outDir, 'brainCloudClient.browser.min.js') });
+
+console.log('Done. Wrote lib/brainCloudClient.browser.js and lib/brainCloudClient.browser.min.js');

--- a/deploy/browser/build.sh
+++ b/deploy/browser/build.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+#
+# Builds a self-contained browser bundle of the brainCloud JS client.
+#
+# The default web/node distribution (autobuild/build_js.sh) is just `cat src/*.js`, which
+# leaves Node `require()` calls (crypto-js, get-user-locale, form-data, buffer) and an
+# appended `exports.*` in the output. That only runs under Node — in a browser it throws
+# "require is not defined" / "exports is not defined".
+#
+# This build resolves those dependencies through esbuild and emits an IIFE that exposes
+# window.BrainCloudWrapper / window.BrainCloudClient, so it works from a single <script>
+# tag with NO external CryptoJS and NO require/exports shims.
+#
+set -e
+cd "$(dirname "$0")"
+
+SRC_DIR="../../src"
+OUT_DIR="lib"
+BUILD_DIR="build"
+
+echo "==> Installing build dependencies"
+npm install --silent
+
+echo "==> Building browser bundle via esbuild"
+node build.mjs
+
+echo "==> Done:"
+ls -lh "$OUT_DIR"/brainCloudClient.browser*.js

--- a/deploy/browser/package.json
+++ b/deploy/browser/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "braincloud-browser-build",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Builds a self-contained browser bundle of the brainCloud JS client (single <script>, no shims).",
+  "scripts": {
+    "build": "./build.sh"
+  },
+  "devDependencies": {
+    "buffer": "^6.0.3",
+    "crypto-js": "^4.2.0",
+    "esbuild": "^0.24.0",
+    "get-user-locale": "^1.4.0"
+  }
+}

--- a/deploy/browser/shims/form-data.js
+++ b/deploy/browser/shims/form-data.js
@@ -1,0 +1,4 @@
+// Browser shim for the Node-only `form-data` package.
+// brainCloudClient-file.js does `window.FormData = require('form-data')` for multipart
+// uploads; browsers ship FormData natively, so resolve the import to the native class.
+module.exports = (typeof FormData !== 'undefined') ? FormData : function FormData() {};

--- a/src/brainCloudClient-identity.js
+++ b/src/brainCloudClient-identity.js
@@ -58,7 +58,7 @@ function BCIdentity () {
     google: 'Google',
     googleOpenId: 'GoogleOpenId',
     twitter: 'Twitter',
-    twitter: 'Apple',
+    apple: 'Apple',
     parse: 'Parse',
     external: 'External',
     unknown: 'UNKNOWN'

--- a/src/brainCloudClient.js
+++ b/src/brainCloudClient.js
@@ -269,14 +269,17 @@ function BrainCloudClient () {
   }
 
   /**
-   * Method initializes the BrainCloudClient. Automatically passes in current serverURL
-   * as https://api.braincloudservers.com/dispatcherv2
+   * Method initializes the BrainCloudClient.
    *
-   * @param secretKey The secret key for your game
    * @param appId The app id
-   * @param appVersion The version
+   * @param secret The secret key for your app
+   * @param appVersion The app version
+   * @param serverUrl Optional. The brainCloud server URL to target, e.g.
+   *   "https://api.braincloudservers.com/dispatcherv2". When omitted, the default
+   *   production server URL is used; pass this to target another environment instead of
+   *   calling setServerUrl() separately.
    */
-  bcc.initialize = function (appId, secret, appVersion) {
+  bcc.initialize = function (appId, secret, appVersion, serverUrl) {
     bcc.resetCommunication()
     function isBlank (str) {
       return !str || /^\s*$/.test(str)
@@ -294,6 +297,12 @@ function BrainCloudClient () {
     bcc.appVersion = appVersion
 
     bcc.brainCloudManager.initialize(appId, secret, appVersion)
+
+    // Optional explicit server URL (e.g. for a non-production cluster). When omitted, the
+    // default production server URL set by brainCloudManager.initialize is kept.
+    if (!isBlank(serverUrl)) {
+      bcc.setServerUrl(serverUrl)
+    }
   }
 
   bcc.initializeWithApps = function (defaultAppId, secretMap, appVersion) {

--- a/src/brainCloudClient.js
+++ b/src/brainCloudClient.js
@@ -305,7 +305,18 @@ function BrainCloudClient () {
     }
   }
 
-  bcc.initializeWithApps = function (defaultAppId, secretMap, appVersion) {
+  /**
+   * Method initializes the BrainCloudClient with multiple app/secret pairs.
+   *
+   * @param defaultAppId The app id to use by default
+   * @param secretMap A map of app ids to secret keys
+   * @param appVersion The app version
+   * @param serverUrl Optional. The brainCloud server URL to target, e.g.
+   *   "https://api.braincloudservers.com/dispatcherv2". When omitted, the default
+   *   production server URL is used; pass this to target another environment instead of
+   *   calling setServerUrl() separately.
+   */
+  bcc.initializeWithApps = function (defaultAppId, secretMap, appVersion, serverUrl) {
     bcc.resetCommunication()
     function isBlank (str) {
       return !str || /^\s*$/.test(str)
@@ -330,6 +341,12 @@ function BrainCloudClient () {
       secretMap,
       appVersion
     )
+
+    // Optional explicit server URL (e.g. for a non-production cluster). When omitted, the
+    // default production server URL set by brainCloudManager.initializeWithApps is kept.
+    if (!isBlank(serverUrl)) {
+      bcc.setServerUrl(serverUrl)
+    }
   }
 
   /**

--- a/src/brainCloudWrapper.js
+++ b/src/brainCloudWrapper.js
@@ -185,25 +185,24 @@ function BrainCloudWrapper (wrapperName) {
   /**
    * Method initializes the BrainCloudClient.
    *
-   * @param serverURL The url to the brainCloud server
-   * @param secretKey The secret key for your app
    * @param appId The app id
-   * @param version The app version
-   * @param companyName The company name used in the keychain for storing anonymous and profile ids.
-   * You are free to pick anything you want.
-   * @param appName The app name used in the keychain for storing anonymous and profile ids.
-   * You are free to pick anything you want.
+   * @param secret The secret key for your app
+   * @param appVersion The app version
+   * @param serverUrl Optional. The brainCloud server URL to target, e.g.
+   *   "https://api.braincloudservers.com/dispatcherv2". When omitted, the default
+   *   production server URL is used; pass this to target another environment instead of
+   *   calling brainCloudClient.setServerUrl() separately.
    */
 
-  bcw.initialize = function (appId, secret, appVersion) {
+  bcw.initialize = function (appId, secret, appVersion, serverUrl) {
     bcw.initializeParams = {
       appId: appId,
       secretKey: secret,
       appVersion: appVersion,
-      serverUrl: '',
+      serverUrl: serverUrl || '',
       secretMap: null
     }
-    bcw.brainCloudClient.initialize(appId, secret, appVersion)
+    bcw.brainCloudClient.initialize(appId, secret, appVersion, serverUrl)
   }
 
   bcw.initializeWithApps = function (defaultAppId, secretMap, appVersion) {

--- a/src/brainCloudWrapper.js
+++ b/src/brainCloudWrapper.js
@@ -146,17 +146,17 @@ function BrainCloudWrapper (wrapperName) {
         bcw.brainCloudClient.initialize(
           bcw.initializeParams.appId,
           bcw.initializeParams.secretKey,
-          bcw.initializeParams.appVersion
+          bcw.initializeParams.appVersion,
+          bcw.initializeParams.serverUrl
         )
-        bcw.brainCloudClient.setServerUrl(bcw.initializeParams.serverUrl)
       } else {
         // For initialize with apps, we ignore the new app id
         bcw.brainCloudClient.initializeWithApps(
           bcw.initializeParams.appId,
           bcw.initializeParams.secretMap,
-          bcw.initializeParams.appVersion
+          bcw.initializeParams.appVersion,
+          bcw.initializeParams.serverUrl
         )
-        bcw.brainCloudClient.setServerUrl(bcw.initializeParams.serverUrl)
       }
 
       bcw._initializeIdentity(true)
@@ -205,15 +205,26 @@ function BrainCloudWrapper (wrapperName) {
     bcw.brainCloudClient.initialize(appId, secret, appVersion, serverUrl)
   }
 
-  bcw.initializeWithApps = function (defaultAppId, secretMap, appVersion) {
+  /**
+   * Method initializes the BrainCloudClient with multiple app/secret pairs.
+   *
+   * @param defaultAppId The app id to use by default
+   * @param secretMap A map of app ids to secret keys
+   * @param appVersion The app version
+   * @param serverUrl Optional. The brainCloud server URL to target, e.g.
+   *   "https://api.braincloudservers.com/dispatcherv2". When omitted, the default
+   *   production server URL is used; pass this to target another environment instead of
+   *   calling brainCloudClient.setServerUrl() separately.
+   */
+  bcw.initializeWithApps = function (defaultAppId, secretMap, appVersion, serverUrl) {
     bcw.initializeParams = {
       appId: defaultAppId,
       secretKey: '',
       appVersion: appVersion,
-      serverUrl: '',
+      serverUrl: serverUrl || '',
       secretMap: secretMap
     }
-    bcw.brainCloudClient.initializeWithApps(defaultAppId, secretMap, appVersion)
+    bcw.brainCloudClient.initializeWithApps(defaultAppId, secretMap, appVersion, serverUrl)
   }
 
   bcw.getStoredAnonymousId = function () {

--- a/test/test.js
+++ b/test/test.js
@@ -189,10 +189,8 @@ function initializeClient()
     var secretMap = {};
     secretMap[GAME_ID] = SECRET;
     secretMap[CHILD_APP_ID] = CHILD_SECRET;
-    bc.brainCloudClient.initializeWithApps(GAME_ID, secretMap, GAME_VERSION);
+    bc.brainCloudClient.initializeWithApps(GAME_ID, secretMap, GAME_VERSION, SERVER_URL);
 
-    // point to internal (default is prod)
-    bc.brainCloudClient.setServerUrl(SERVER_URL);
 
     bc.brainCloudClient.authentication.clearSavedProfileId();
 }
@@ -3271,9 +3269,7 @@ async function testGroup() {
 async function testIdentity() {
     bc.brainCloudClient.setDebugEnabled(true)
 
-    bc.initialize(GAME_ID, SECRET, GAME_VERSION)
-
-    bc.brainCloudClient.setServerUrl(SERVER_URL)
+    bc.initialize(GAME_ID, SECRET, GAME_VERSION, SERVER_URL)
 
     var today = new Date()
     var time = today.getTime()
@@ -6354,11 +6350,7 @@ async function testWrapper()
     bc.brainCloudClient.setDebugEnabled(true);
 
     //initialize with our game id, secret and game version
-    bc.initialize(GAME_ID, SECRET, GAME_VERSION);
-
-    // point to internal (default is prod)
-    bc.brainCloudClient.setServerUrl(SERVER_URL);
-
+    bc.initialize(GAME_ID, SECRET, GAME_VERSION, SERVER_URL);
 
     await asyncTest("authenticateAnonymous()", 2, function() {
         bc.resetStoredProfileId();
@@ -6672,8 +6664,7 @@ async function testWrapper()
         var secretMap1 = {}
         secretMap1[GAME_ID] = SECRET
         secretMap1[CHILD_APP_ID] = CHILD_SECRET
-        wrapper1.brainCloudClient.initializeWithApps(GAME_ID, secretMap1, GAME_VERSION)
-        wrapper1.brainCloudClient.setServerUrl(SERVER_URL);
+        wrapper1.brainCloudClient.initializeWithApps(GAME_ID, secretMap1, GAME_VERSION, SERVER_URL)
         wrapper1.brainCloudClient.authentication.clearSavedProfileId();
 
         var wrapper2 = new BC.BrainCloudWrapper("JSWrapper2")
@@ -6682,8 +6673,7 @@ async function testWrapper()
         var secretMap2 = {}
         secretMap2[GAME_ID] = SECRET
         secretMap2[CHILD_APP_ID] = CHILD_SECRET
-        wrapper2.brainCloudClient.initializeWithApps(GAME_ID, secretMap2, GAME_VERSION)
-        wrapper2.brainCloudClient.setServerUrl(SERVER_URL);
+        wrapper2.brainCloudClient.initializeWithApps(GAME_ID, secretMap2, GAME_VERSION, SERVER_URL)
         wrapper2.brainCloudClient.authentication.clearSavedProfileId();
 
         // Register a callback for when the long session re-authentication response is received


### PR DESCRIPTION
## Summary

Makes the brainCloud JS client genuinely browser-friendly and fixes a data bug in the auth-type map.

### 1. `initialize()` accepts an optional `serverUrl` (BCLOUD-13977)
`initialize(appId, secret, appVersion, serverUrl)` on both `brainCloudWrapper.js` and `brainCloudClient.js`. When supplied, the client targets that server directly; when omitted it behaves exactly as before (production default), so this is **backward-compatible** — existing 3-arg callers are unchanged. Removes the need for a separate `brainCloudClient.setServerUrl()` call when targeting a non-production cluster. Also corrects the wrapper's stale JSDoc (it documented a wrong 6-arg signature).

> JavaScript has no method overloading, so this is a single optional trailing parameter rather than a second `initialize` signature.

### 2. Fix `authenticationType` map (`brainCloudClient-identity.js`)
A duplicate key meant `twitter: 'Apple'` overwrote `twitter: 'Twitter'`. Restored `twitter: 'Twitter'` and added the previously-missing `apple: 'Apple'`. Before this, `authenticationType.twitter` returned `'Apple'` and there was no `apple` key. Confirmed against the C# SDK (`AuthenticationType.Apple = "Apple"`).

### 3. New `deploy/browser/` — self-contained browser bundle
An esbuild build that emits `brainCloudClient.browser.js` / `.browser.min.js`. It bundles `crypto-js`/`get-user-locale`/`buffer` and maps `form-data` to the native `FormData`, exposing `window.BrainCloudWrapper` / `BrainCloudClient`. Loads from a single `<script>` with **no external CryptoJS and no `require`/`exports` shims** — closing the packaging gap that previously forced browser users to hand-roll shims.

Purely additive: does **not** touch `autobuild/build_js.sh` (web zip), `deploy/node/`, or `deploy/k6/`.

## Test plan
- Built the browser bundle (`deploy/browser/build.sh`) and ran it in a real browser against a dev-internal app:
  - 4-arg `initialize(...)` → `authenticateAnonymous` returned **status 200** with no `setServerUrl()` call.
  - `authenticationType.twitter === 'Twitter'` and `authenticationType.apple === 'Apple'`.
  - Globals exposed, `require`/global `CryptoJS` undefined, console clean.
- Source edits verified to sit outside all `//> ... IF K6` marker blocks; no build scripts changed, so web/node/k6 builds are unaffected and pick up fixes #1/#2 on next build.
- ⚠️ K6 build not run here (its marker preprocessor lives in CI, not this repo) — worth a CI run before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)